### PR TITLE
ci: Create IG pipeline to s3 bucket

### DIFF
--- a/.github/workflows/releaseBuild.yaml
+++ b/.github/workflows/releaseBuild.yaml
@@ -45,8 +45,7 @@ jobs:
         with:
           # Get the latest publisher - don't run the batch script but run the line directly
           args: >-
-            curl -L https://github.com/HL7/fhir-ig-publisher/releases/latest/download/publisher.jar
-                 -o ./input-cache/publisher.jar --create-dirs
+            curl -L https://github.com/HL7/fhir-ig-publisher/releases/latest/download/publisher.jar -o ./input-cache/publisher.jar --create-dirs
 
       - name: Create package cache folder
         uses: docker://hl7fhir/ig-publisher-base:latest

--- a/.github/workflows/releaseBuild.yaml
+++ b/.github/workflows/releaseBuild.yaml
@@ -74,10 +74,10 @@ jobs:
     runs-on: "ubuntu-latest"
     needs: build
     # Only deploy on pushes to master.
-    #if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master'
       
     env:
-      AWS_BUCKET: "ehealth-documentation-github"
+      AWS_BUCKET: "ehealth-documentation"
       DEST_DIR: "latest/ig"
 
     steps:

--- a/.github/workflows/releaseBuild.yaml
+++ b/.github/workflows/releaseBuild.yaml
@@ -43,7 +43,7 @@ jobs:
           path: |
             static/**
             output/**
-            fsh-content/sushi-config.yaml
+            sushi-config.yaml
           key: ${{ runner.os }}-fsh-${{ hashFiles('static/**') }}-${{ hashFiles('output/**') }}
           restore-keys: ${{ runner.os }}-fsh-
 
@@ -90,7 +90,7 @@ jobs:
           path: |
             static/**
             output/**
-            fsh-content/sushi-config.yaml
+            sushi-config.yaml
           key: ${{ runner.os }}-fsh-${{ hashFiles('static/**') }}-${{ hashFiles('output/**') }}
       
         # Load the IG config from the sushi-config.yaml file.

--- a/.github/workflows/releaseBuild.yaml
+++ b/.github/workflows/releaseBuild.yaml
@@ -98,7 +98,7 @@ jobs:
         id: ig-version
         uses: pietrobolcato/action-read-yaml@1.1.0
         with:
-          config: ${{ github.workspace }}/fsh-content/sushi-config.yaml
+          config: ${{ github.workspace }}/sushi-config.yaml
         
         # Change the default destination directory to the IG version if it's not the latest.
       - name: IG Path version
@@ -115,7 +115,7 @@ jobs:
           secret_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
 
       - name: Deploy IG to S3
-        run: s3cmd sync --delete-removed --acl-public --no-mime-magic --guess-mime-type --no-preserve --no-progress --verbose --recursive output/ s3://${{ env.AWS_BUCKET }}/${{ env.DEST_DIR }}
+        run: s3cmd sync --delete-removed --acl-public --no-mime-magic --guess-mime-type --no-preserve --no-progress --verbose --recursive output/ s3://${{ env.AWS_BUCKET }}/${{ env.DEST_DIR }}/
 
       - name: Deploy static files to S3
         run: |
@@ -130,4 +130,4 @@ jobs:
 
       - name: Deploy latest released to S3
         if: steps.ig-version.outputs['version'] == 'latest'
-        run: s3cmd sync --delete-removed --acl-public --no-mime-magic --guess-mime-type --no-preserve --no-progress --verbose --recursive output/ s3://${{ env.AWS_BUCKET }}/latest-released/ig
+        run: s3cmd sync --delete-removed --acl-public --no-mime-magic --guess-mime-type --no-preserve --no-progress --verbose --recursive output/ s3://${{ env.AWS_BUCKET }}/latest-released/ig/

--- a/.github/workflows/releaseBuild.yaml
+++ b/.github/workflows/releaseBuild.yaml
@@ -74,10 +74,10 @@ jobs:
     runs-on: "ubuntu-latest"
     needs: build
     # Only deploy on pushes to master.
-    if: github.ref == 'refs/heads/master'
+    #if: github.ref == 'refs/heads/master'
       
     env:
-      AWS_BUCKET: "ehealth-documentation"
+      AWS_BUCKET: "ehealth-documentation-github"
       DEST_DIR: "latest/ig"
 
     steps:

--- a/.github/workflows/releaseBuild.yaml
+++ b/.github/workflows/releaseBuild.yaml
@@ -1,0 +1,61 @@
+# ReleaseBuild Workflow
+#
+# This GitHub Actions workflow performs the publication process for a FHIR IG Release.
+#
+# Based on these workflows:
+# https://github.com/medigree/base/blob/main/.github/workflows/ghbuild.yml
+# https://github.com/WorldHealthOrganization/smart-html/blob/main/.github/workflows/release.yml
+
+name: "ReleaseBuild"
+
+# Controls when the action will run.
+on:
+  workflow_call: # Reusable by other workflows.
+  # Triggers the workflow on push or pull request events.
+  push:
+    branches: # Only triggers on pushes on these branches.
+      - "master"
+      #- "releases/**"
+  pull_request:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: "ubuntu-latest"
+    env:
+      #GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Get branch name
+        run: echo ${GITHUB_REF##*/}
+
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+
+      - name: Update the image to the latest publisher
+        uses: docker://hl7fhir/ig-publisher-base:latest
+        with:
+          # Get the latest publisher - don't run the batch script but run the line directly
+          args: >
+            curl -L https://github.com/HL7/fhir-ig-publisher/releases/latest/download/publisher.jar
+                 -o ./input-cache/publisher.jar --create-dirs
+
+      - name: Create package cache folder
+        uses: docker://hl7fhir/ig-publisher-base:latest
+        with:
+          entrypoint: /bin/sh
+          args: -c "mkdir -p ./fhir-package-cache && chown 1001:127 ./fhir-package-cache"
+
+      - name: Run the IG publisher
+        uses: docker://hl7fhir/ig-publisher-base:latest
+        with:
+          # Run the publisher - don't run the batch script but run the line directly
+          args: >
+            java -Xmx4g -jar ./input-cache/publisher.jar publisher -ig . -auto-ig-build
+                 -repo https://github.com/${{github.repository}} -package-cache-folder ./fhir-package-cache

--- a/.github/workflows/releaseBuild.yaml
+++ b/.github/workflows/releaseBuild.yaml
@@ -73,6 +73,7 @@ jobs:
 
   release:
     runs-on: "ubuntu-latest"
+    needs: build
     # Only deploy on pushes to master.
     #if: github.ref == 'refs/heads/master'
       
@@ -95,7 +96,7 @@ jobs:
         # Load the IG config from the sushi-config.yaml file.
       - name: IG Version
         id: ig-version
-        uses: pietrobolcato/action-read-yaml@1
+        uses: pietrobolcato/action-read-yaml@1.1
         with:
           config: ${{ github.workspace }}/fsh-content/sushi-config.yaml
         

--- a/.github/workflows/releaseBuild.yaml
+++ b/.github/workflows/releaseBuild.yaml
@@ -91,6 +91,7 @@ jobs:
             output/**
             sushi-config.yaml
           key: ${{ runner.os }}-fsh-${{ hashFiles('static/**') }}-${{ hashFiles('output/**') }}
+          restore-keys: ${{ runner.os }}-fsh-
       
         # Load the IG config from the sushi-config.yaml file.
       - name: IG Version

--- a/.github/workflows/releaseBuild.yaml
+++ b/.github/workflows/releaseBuild.yaml
@@ -29,13 +29,23 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: "ubuntu-latest"
-    #env:
-      #GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Get branch name
         run: echo ${GITHUB_REF##*/}
+      
+        # Cache Fish output for usage in other jobs.
+      - name: Output cache
+        id: fsh-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            static/**
+            output/**
+            fsh-content/sushi-config.yaml
+          key: ${{ runner.os }}-fsh-${{ hashFiles('static/**') }}-${{ hashFiles('output/**') }}
+          restore-keys: ${{ runner.os }}-fsh-
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
@@ -60,3 +70,63 @@ jobs:
           args: >
             java -Xmx4g -jar ./input-cache/publisher.jar publisher -ig . -auto-ig-build
                  -repo https://github.com/${{github.repository}} -package-cache-folder ./fhir-package-cache
+
+  release:
+    runs-on: "ubuntu-latest"
+    # Only deploy on pushes to master.
+    #if: github.ref == 'refs/heads/master'
+      
+    env:
+      AWS_BUCKET: "ehealth-documentation-github"
+      DEST_DIR: "latest/ig"
+
+    steps:
+        # Retrieve cached Fish output.
+      - name: Output cache
+        id: fsh-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            static/**
+            output/**
+            fsh-content/sushi-config.yaml
+          key: ${{ runner.os }}-fsh-${{ hashFiles('static/**') }}-${{ hashFiles('output/**') }}
+      
+        # Load the IG config from the sushi-config.yaml file.
+      - name: IG Version
+        id: ig-version
+        uses: pietrobolcato/action-read-yaml@1
+        with:
+          config: ${{ github.workspace }}/fsh-content/sushi-config.yaml
+        
+        # Change the default destination directory to the IG version if it's not the latest.
+      - name: IG Path version
+        if: steps.ig-version.outputs["version"] != "latest"
+        run: echo "DEST_DIR=v${{ steps.ig-version.outputs["version"] }}/ig" >> "$GITHUB_ENV"
+
+        # Configure the AWS CLI.
+      - name: Set up S3cmd cli tool
+        uses: s3-actions/s3cmd@v1
+        with:
+          provider: aws # default is linode
+          region: 'eu-west-1'
+          access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          secret_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
+
+      - name: Deploy IG to S3
+        run: s3cmd sync --delete-removed --acl-public --no-mime-magic --guess-mime-type --no-preserve --no-progress --verbose --recursive output/ s3://${{ env.AWS_BUCKET }}/${{ env.DEST_DIR }}
+
+      - name: Deploy static files to S3
+        run: |
+          s3cmd del --force "s3://${{ env.AWS_BUCKET }}/index.html"
+          s3cmd put --acl-public --no-mime-magic --guess-mime-type --no-preserve --no-progress --verbose "static/index.html" "s3://${{ env.AWS_BUCKET }}/index.html"
+
+          s3cmd del --force "s3://${{ env.AWS_BUCKET }}/sitemap.txt"
+          s3cmd put --acl-public --no-mime-magic --guess-mime-type --no-preserve --no-progress --verbose "static/sitemap.txt" "s3://${{ env.AWS_BUCKET }}/sitemap.txt"
+
+          s3cmd del --force "s3://${{ env.AWS_BUCKET }}/robots.txt"
+          s3cmd put --acl-public --no-mime-magic --guess-mime-type --no-preserve --no-progress --verbose "static/robots.txt" "s3://${{ env.AWS_BUCKET }}/robots.txt"
+
+      - name: Deploy latest released to S3
+        if: steps.ig-version.outputs["version"] == "latest"
+        run: s3cmd sync --delete-removed --acl-public --no-mime-magic --guess-mime-type --no-preserve --no-progress --verbose --recursive output/ s3://${{ env.AWS_BUCKET }}/latest-released/ig

--- a/.github/workflows/releaseBuild.yaml
+++ b/.github/workflows/releaseBuild.yaml
@@ -96,7 +96,7 @@ jobs:
         # Load the IG config from the sushi-config.yaml file.
       - name: IG Version
         id: ig-version
-        uses: pietrobolcato/action-read-yaml@1.1
+        uses: pietrobolcato/action-read-yaml@1.1.0
         with:
           config: ${{ github.workspace }}/fsh-content/sushi-config.yaml
         

--- a/.github/workflows/releaseBuild.yaml
+++ b/.github/workflows/releaseBuild.yaml
@@ -101,7 +101,7 @@ jobs:
         
         # Change the default destination directory to the IG version if it's not the latest.
       - name: IG Path version
-        if: steps.ig-version.outputs["version"] != "latest"
+        if: steps.ig-version.outputs['version'] != "latest"
         run: echo "DEST_DIR=v${{ steps.ig-version.outputs['version'] }}/ig" >> "$GITHUB_ENV"
 
         # Configure the AWS CLI.
@@ -128,5 +128,5 @@ jobs:
           s3cmd put --acl-public --no-mime-magic --guess-mime-type --no-preserve --no-progress --verbose "static/robots.txt" "s3://${{ env.AWS_BUCKET }}/robots.txt"
 
       - name: Deploy latest released to S3
-        if: steps.ig-version.outputs["version"] == "latest"
+        if: steps.ig-version.outputs['version'] == "latest"
         run: s3cmd sync --delete-removed --acl-public --no-mime-magic --guess-mime-type --no-preserve --no-progress --verbose --recursive output/ s3://${{ env.AWS_BUCKET }}/latest-released/ig

--- a/.github/workflows/releaseBuild.yaml
+++ b/.github/workflows/releaseBuild.yaml
@@ -102,7 +102,7 @@ jobs:
         # Change the default destination directory to the IG version if it's not the latest.
       - name: IG Path version
         if: steps.ig-version.outputs["version"] != "latest"
-        run: echo "DEST_DIR=v${{ steps.ig-version.outputs["version"] }}/ig" >> "$GITHUB_ENV"
+        run: echo "DEST_DIR=v${{ steps.ig-version.outputs['version'] }}/ig" >> "$GITHUB_ENV"
 
         # Configure the AWS CLI.
       - name: Set up S3cmd cli tool

--- a/.github/workflows/releaseBuild.yaml
+++ b/.github/workflows/releaseBuild.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: docker://hl7fhir/ig-publisher-base:latest
         with:
           # Get the latest publisher - don't run the batch script but run the line directly
-          args: >
+          args: >-
             curl -L https://github.com/HL7/fhir-ig-publisher/releases/latest/download/publisher.jar
                  -o ./input-cache/publisher.jar --create-dirs
 

--- a/.github/workflows/releaseBuild.yaml
+++ b/.github/workflows/releaseBuild.yaml
@@ -114,20 +114,15 @@ jobs:
           access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
           secret_key: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
 
-      - name: Deploy IG to S3
-        run: s3cmd sync --delete-removed --acl-public --no-mime-magic --guess-mime-type --no-preserve --no-progress --verbose --recursive output/ s3://${{ env.AWS_BUCKET }}/${{ env.DEST_DIR }}/
-
+        # This deploys all files in the static folder to the root of the s3 bucket and thus the root of the website.
       - name: Deploy static files to S3
-        run: |
-          s3cmd del --force "s3://${{ env.AWS_BUCKET }}/index.html"
-          s3cmd put --acl-public --no-mime-magic --guess-mime-type --no-preserve --no-progress --verbose "static/index.html" "s3://${{ env.AWS_BUCKET }}/index.html"
+        run: s3cmd sync --delete-removed --no-mime-magic --guess-mime-type --no-preserve --no-progress --verbose --recursive static/ s3://${{ env.AWS_BUCKET }}/
 
-          s3cmd del --force "s3://${{ env.AWS_BUCKET }}/sitemap.txt"
-          s3cmd put --acl-public --no-mime-magic --guess-mime-type --no-preserve --no-progress --verbose "static/sitemap.txt" "s3://${{ env.AWS_BUCKET }}/sitemap.txt"
+        # Deploy the IG to the correct folder in the S3 bucket.
+      - name: Deploy IG to S3
+        run: s3cmd sync --delete-removed --no-mime-magic --guess-mime-type --no-preserve --no-progress --verbose --recursive output/ s3://${{ env.AWS_BUCKET }}/${{ env.DEST_DIR }}/
 
-          s3cmd del --force "s3://${{ env.AWS_BUCKET }}/robots.txt"
-          s3cmd put --acl-public --no-mime-magic --guess-mime-type --no-preserve --no-progress --verbose "static/robots.txt" "s3://${{ env.AWS_BUCKET }}/robots.txt"
-
+        # When we are on latest, we update the latest-released folder as well.
       - name: Deploy latest released to S3
         if: steps.ig-version.outputs['version'] == 'latest'
-        run: s3cmd sync --delete-removed --acl-public --no-mime-magic --guess-mime-type --no-preserve --no-progress --verbose --recursive output/ s3://${{ env.AWS_BUCKET }}/latest-released/ig/
+        run: s3cmd sync --delete-removed --no-mime-magic --guess-mime-type --no-preserve --no-progress --verbose --recursive output/ s3://${{ env.AWS_BUCKET }}/latest-released/ig/

--- a/.github/workflows/releaseBuild.yaml
+++ b/.github/workflows/releaseBuild.yaml
@@ -13,10 +13,9 @@ on:
   workflow_call: # Reusable by other workflows.
   # Triggers the workflow on push or pull request events.
   push:
-    branches: # Only triggers on pushes on these branches.
+    branches: 
+      # Only triggers on pushes on these branches.
       - "master"
-        # Temporarily enable to test the workflow on a feature branch.
-      - "*/feature/**"
       #- "releases/**"
   pull_request:
 
@@ -75,10 +74,10 @@ jobs:
     runs-on: "ubuntu-latest"
     needs: build
     # Only deploy on pushes to master.
-    #if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master'
       
     env:
-      AWS_BUCKET: "ehealth-documentation-github"
+      AWS_BUCKET: "ehealth-documentation"
       DEST_DIR: "latest/ig"
 
     steps:

--- a/.github/workflows/releaseBuild.yaml
+++ b/.github/workflows/releaseBuild.yaml
@@ -29,7 +29,7 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: "ubuntu-latest"
-    env:
+    #env:
       #GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/releaseBuild.yaml
+++ b/.github/workflows/releaseBuild.yaml
@@ -15,6 +15,8 @@ on:
   push:
     branches: # Only triggers on pushes on these branches.
       - "master"
+        # Temporarily enable to test the workflow on a feature branch.
+      - "*/feature/**"
       #- "releases/**"
   pull_request:
 

--- a/.github/workflows/releaseBuild.yaml
+++ b/.github/workflows/releaseBuild.yaml
@@ -33,18 +33,6 @@ jobs:
     steps:
       - name: Get branch name
         run: echo ${GITHUB_REF##*/}
-      
-        # Cache Fish output for usage in other jobs.
-      - name: Output cache
-        id: fsh-cache
-        uses: actions/cache@v3
-        with:
-          path: |
-            static/**
-            output/**
-            sushi-config.yaml
-          key: ${{ runner.os }}-fsh-${{ hashFiles('static/**') }}-${{ hashFiles('output/**') }}
-          restore-keys: ${{ runner.os }}-fsh-
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
@@ -69,6 +57,18 @@ jobs:
           args: >
             java -Xmx4g -jar ./input-cache/publisher.jar publisher -ig . -auto-ig-build
                  -repo https://github.com/${{github.repository}} -package-cache-folder ./fhir-package-cache
+      
+        # Cache Fish output for usage in other jobs.
+      - name: Output cache
+        id: fsh-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            static/**
+            output/**
+            sushi-config.yaml
+          key: ${{ runner.os }}-fsh-${{ hashFiles('static/**') }}-${{ hashFiles('output/**') }}
+          restore-keys: ${{ runner.os }}-fsh-
 
   release:
     runs-on: "ubuntu-latest"

--- a/.github/workflows/releaseBuild.yaml
+++ b/.github/workflows/releaseBuild.yaml
@@ -101,7 +101,7 @@ jobs:
         
         # Change the default destination directory to the IG version if it's not the latest.
       - name: IG Path version
-        if: steps.ig-version.outputs['version'] != "latest"
+        if: steps.ig-version.outputs['version'] != 'latest'
         run: echo "DEST_DIR=v${{ steps.ig-version.outputs['version'] }}/ig" >> "$GITHUB_ENV"
 
         # Configure the AWS CLI.
@@ -128,5 +128,5 @@ jobs:
           s3cmd put --acl-public --no-mime-magic --guess-mime-type --no-preserve --no-progress --verbose "static/robots.txt" "s3://${{ env.AWS_BUCKET }}/robots.txt"
 
       - name: Deploy latest released to S3
-        if: steps.ig-version.outputs['version'] == "latest"
+        if: steps.ig-version.outputs['version'] == 'latest'
         run: s3cmd sync --delete-removed --acl-public --no-mime-magic --guess-mime-type --no-preserve --no-progress --verbose --recursive output/ s3://${{ env.AWS_BUCKET }}/latest-released/ig


### PR DESCRIPTION
Create a release workflow that does the following:
- Run a build when: PR is created and on pushes to master
  - This checks that the PR does not break the build job
- Run the release job on pushes to master
  - With the branch rule that prevents changes to master without a PR this ensures that we only update the IG on successful PR merges

I've tested the release job on this s3 bucket, which we should delete after merging this PR: http://ehealth-documentation-github.s3-website-eu-west-1.amazonaws.com/ - Compare this with the "real" bucket on http://ehealth-documentation.s3-website-eu-west-1.amazonaws.com/ and https://docs.ehealth.sundhed.dk/

Here is the old pipeline: https://github.com/fut-infrastructure/implementation-guide/blob/master/Jenkinsfile