### PR TITLE
ci: Configure non-first consecutive releases

### DIFF
--- a/publication-request.json
+++ b/publication-request.json
@@ -10,6 +10,6 @@
   "introduction": "A FHIR Implementation Guide for FUT Infrastructure",
   "desc": "FUT Infrastructure version 3.3.0",
   "descmd": "@release-notes.md",
-  "first": true,
+  "first": false,
   "ci-build": "https://build.fhir.org/ig/fut-infrastructure/implementation-guide/"
 }

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,1 +1,0 @@
-* Initial formal release


### PR DESCRIPTION
Set first to false and empty the release notes, to either be used in a later commit or by the pipeline.

This is to configure the pipeline for the next IG release/publication.

I've redeployed the latest publication (3.1.0) to https://fut-infrastructure.github.io/fut-ig-website/fhir/ (this will be https://ehealth.sundhed.dk/fhir when Netic is done modifying DNS). I've done this by cherry picking commits and the new workflow and moved the tag to include that: https://github.com/fut-infrastructure/implementation-guide/compare/master...3.1.0

If you think that publication is good, we should do the foillowing after merge of this PR:
- Update the bingo plate for 3.1.0 to point to the new URL (https://gitlab.admin.ehealth.sundhed.dk/common/ehealth-docs/-/blob/master/static/index.html)
- Delete this branch: https://github.com/fut-infrastructure/implementation-guide/tree/trifork/feature/build-publish-new-infra