### PR TITLE
FUT1-16621 Add HandoverNegotiation to Task Category

### DIFF
--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -10,8 +10,10 @@ This is the log of changes made to the eHealth Implementation Guide.
 #### Instance operations
 ### Code systems
 - Added http://ehealth.sundhed.dk/cs/participant-function
+- Added `HandoverNegotiation` code to http://ehealth.sundhed.dk/cs/task-category
 ### ValueSets
 - Added http://ehealth.sundhed.dk/vs/participant-function
+- Added `HandoverNegotiation` code to http://ehealth.sundhed.dk/vs/task-category
 ### ConceptMaps
 ### Resource/profile changes
 - Added new generic extension ehealth-participant to be used on all resources where a participant is involved

--- a/input/resources/CodeSystem-ehealth-task-category.json
+++ b/input/resources/CodeSystem-ehealth-task-category.json
@@ -198,6 +198,17 @@
           "value": "Indsendte måledata (måling) har fravær af målt værdi."
         }
       ]
+    },
+    {
+      "code": "HandoverNegotiation",
+      "display": "Need negotiation for handover of CarePlans between CareTeams",
+      "definition": "Need negotiation for handover of CarePlans between CareTeams",
+      "designation": [
+        {
+          "language": "da",
+          "value": "Forhandlingsprocess for overdragelse af plan(er) mellem behandlerteams"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Add code for HandoverNegotiation to Task Category (the codes have already been manually added to EXTTEST, DEVENVCGI and PROD)