### PR TITLE
FUT1-19071 action behaviour supplement formatting

### DIFF
--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -10,6 +10,7 @@ This is the log of changes made to the eHealth Implementation Guide.
 
 ### Code systems
 - Added new participant function to http://ehealth.sundhed.dk/cs/participant-function
+- Updated supplement values for http://ehealth.sundhed.dk/hl7.org/fhir/action-selection-behavior-supplement
 ### ValueSets
 ### ConceptMaps
 ### Resource/profile changes

--- a/input/resources/CodeSystem-ehealth-supplement-action-selection-behavior.json
+++ b/input/resources/CodeSystem-ehealth-supplement-action-selection-behavior.json
@@ -83,7 +83,7 @@
             "system": "http://snomed.info/sct",
             "code": "900000000000013009"
           },
-          "value": "Alle eller Ingen"
+          "value": "Alle eller ingen"
         }
       ]
     },
@@ -98,7 +98,7 @@
             "system": "http://snomed.info/sct",
             "code": "900000000000013009"
           },
-          "value": "Præcis En"
+          "value": "Præcis en"
         }
       ]
     },
@@ -113,7 +113,7 @@
             "system": "http://snomed.info/sct",
             "code": "900000000000013009"
           },
-          "value": "Højst En"
+          "value": "Højst en"
         }
       ]
     },
@@ -128,7 +128,7 @@
             "system": "http://snomed.info/sct",
             "code": "900000000000013009"
           },
-          "value": "En Eller Flere"
+          "value": "En eller flere"
         }
       ]
     }


### PR DESCRIPTION
- [x] I have ensured the target branch is correct; for new changes, they target e.g. `release-3.5.0`. Only release branches should target `master`. For more details, see [here](../RELEASE.md).

The IG is materialised as a website automatically by CI, and can be found [here](http://build.fhir.org/ig/fut-infrastructure/implementation-guide/branches/).