### PR TITLE
docs: update RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,12 +5,9 @@
 	- The `release` prefix ensures the right branch-protection rules are applied
 
 ## Releasing
-- A PR is created from the release branch (e.g. `release-3.5.0` targeting `master`. It requires 2 reviews, one from Systematic, one from TRIFORK.
-- Merge into `master`. If the last commit is tagged, 
-- The page [create a new release](https://github.com/fut-infrastructure/implementation-guide/releases/new) can be used to create a new tag with a description of the new release, which triggers publication through [this](./.github/workflows/publish.yaml) workflow. The version (for `sushi-config.yaml`) is automatically inferred from the tag. 
-
-That will publish the new version on the HL7 CI/CD infrastructure
-(see the above sections), and on the FUT ehealth documentation website.
+- A PR is created from the release branch (e.g. `release-3.5.0` targeting `master`). It requires 2 reviews, one from Systematic, one from TRIFORK.
+- Merge into `master`.
+- Use [create a new release](https://github.com/fut-infrastructure/implementation-guide/releases/new) to create a new tag with a description of the new release. If the tag follows SemVer (e.g. `3.5.0`), it triggers publication through [this](./.github/workflows/publish.yaml) workflow. The version (for `sushi-config.yaml`) is automatically inferred from the tag. 
 
 ## Hotfixing
 - Create a new hotfix branch, e.g. `release-3.5.1`


### PR DESCRIPTION
- [ ] I have ensured the target branch is correct; for new changes, they target e.g. `release-3.5.0`. Only release branches should target `master`. For more details, see [here](../RELEASE.md).

The IG is materialised as a website automatically by CI, and can be found [here](http://build.fhir.org/ig/fut-infrastructure/implementation-guide/branches/).