### PR TITLE
Update sushi-config.yaml

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -7,7 +7,7 @@ canonical: http://ehealth.sundhed.dk/fhir
 name: eHealth Infrastructure
 title: eHealth Infrastructure
 status: active # draft | active | retired | unknown
-version: 3.5.0 # This is overridden by .github/workflows/publish.yaml at publication-time
+version: 3.6.0 # This is overridden by .github/workflows/publish.yaml at publication-time
 fhirVersion: 4.0.1
 copyrightYear: 2021+
 


### PR DESCRIPTION
- [ ] I have ensured the target branch is correct; for new changes, they target e.g. `release-3.5.0`. Only release branches should target `master`. For more details, see [here](../RELEASE.md).

The IG is materialised as a website automatically by CI, and can be found [here](http://build.fhir.org/ig/fut-infrastructure/implementation-guide/branches/).