### PR TITLE
docs: update RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,7 @@
   - Confirm that the tag being released is also the version in `sushi-config.yaml`
 - Merge into `master`.
 - Use [create a new release](https://github.com/fut-infrastructure/implementation-guide/releases/new) to create a new tag with a description of the new release. If the tag follows SemVer (e.g. `3.5.0`), it triggers publication through [this](./.github/workflows/publish.yaml) workflow.
+  - If the branch does not build the IG, check at [FHIRs chat](https://chat.fhir.org/#narrow/channel/179297-committers.2Fnotification/topic/ig-build/with/515282620) for the error
 
 ## Hotfixing
 - Create a new hotfix branch, e.g. `release-3.5.1`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,11 +6,12 @@
 
 ## Releasing
 - A PR is created from the release branch (e.g. `release-3.5.0` targeting `master`). It requires 2 reviews, one from Systematic, one from TRIFORK.
-  - Confirm that the changelog has a heading matching the current tag being release
-  - Confirm that the tag being released is also the version in `sushi-config.yaml`
+  - Based on the changelog, decide on the new version. If any breaking changes, make sure to do a major version bump (e.g. 3.5.0 -> 4.0.0).
+  - Confirm that the changelog has a heading matching the current version being released
 - Merge into `master`.
-- Use [create a new release](https://github.com/fut-infrastructure/implementation-guide/releases/new) to create a new tag with a description of the new release. If the tag follows SemVer (e.g. `3.5.0`), it triggers publication through [this](./.github/workflows/publish.yaml) workflow.
+- Use [create a new release](https://github.com/fut-infrastructure/implementation-guide/releases/new) to create a new tag with a description of the new release. It should follow SemVer (e.g. `3.5.0`), which triggers publication through [this](./.github/workflows/publish.yaml) workflow.
   - If the branch does not build the IG, check at [FHIRs chat](https://chat.fhir.org/#narrow/channel/179297-committers.2Fnotification/topic/ig-build/with/515282620) for the error
+  - If the build fails, we will have to fix the cause, and then do a new patch-release. Otherwise, we will get git tag naming conflicts.
 
 ## Hotfixing
 - Create a new hotfix branch, e.g. `release-3.5.1`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,11 +7,11 @@
 ## Releasing
 - A PR is created from the release branch (e.g. `release-3.5.0` targeting `master`). It requires 2 reviews, one from Systematic, one from TRIFORK.
   - Based on the changelog, decide on the new version. If any breaking changes, make sure to do a major version bump (e.g. 3.5.0 -> 4.0.0).
-  - Confirm that the changelog has a heading matching the current version being released
+  - Update the changelog so its heading matches the version being released. It does not matter if it does not match the branch name.
 - Merge into `master`.
-- Use [create a new release](https://github.com/fut-infrastructure/implementation-guide/releases/new) to create a new tag with a description of the new release. It should follow SemVer (e.g. `3.5.0`), which triggers publication through [this](./.github/workflows/publish.yaml) workflow.
+- Use [create a new release](https://github.com/fut-infrastructure/implementation-guide/releases/new) to create a new tag with a description of the new release. It should follow SemVer, and match the version in the changelog. Any SemVer tag triggers triggers publication through [this](./.github/workflows/publish.yaml) workflow.
+  - If the build fails, fix the cause, bump the version in the changelog, and then do a new patch-release. Otherwise, we will get git tag naming conflicts.
   - If the branch does not build the IG, check at [FHIRs chat](https://chat.fhir.org/#narrow/channel/179297-committers.2Fnotification/topic/ig-build/with/515282620) for the error
-  - If the build fails, we will have to fix the cause, and then do a new patch-release. Otherwise, we will get git tag naming conflicts.
 
 ## Hotfixing
 - Create a new hotfix branch, e.g. `release-3.5.1`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,8 +6,10 @@
 
 ## Releasing
 - A PR is created from the release branch (e.g. `release-3.5.0` targeting `master`). It requires 2 reviews, one from Systematic, one from TRIFORK.
+  - Confirm that the changelog has a heading matching the current tag being release
+  - Confirm that the tag being released is also the version in `sushi-config.yaml`
 - Merge into `master`.
-- Use [create a new release](https://github.com/fut-infrastructure/implementation-guide/releases/new) to create a new tag with a description of the new release. If the tag follows SemVer (e.g. `3.5.0`), it triggers publication through [this](./.github/workflows/publish.yaml) workflow. The version (for `sushi-config.yaml`) is automatically inferred from the tag. 
+- Use [create a new release](https://github.com/fut-infrastructure/implementation-guide/releases/new) to create a new tag with a description of the new release. If the tag follows SemVer (e.g. `3.5.0`), it triggers publication through [this](./.github/workflows/publish.yaml) workflow.
 
 ## Hotfixing
 - Create a new hotfix branch, e.g. `release-3.5.1`


### PR DESCRIPTION
- [ ] I have ensured the target branch is correct; for new changes, they target e.g. `release-3.5.0`. Only release branches should target `master`. For more details, see [here](../RELEASE.md).

The IG is materialised as a website automatically by CI, and can be found [here](http://build.fhir.org/ig/fut-infrastructure/implementation-guide/branches/).