### PR TITLE
Fut1 19349 errors in fhir validation clinical impression

### DIFF
--- a/input/fsh/ehealth-clinicalimpression.fsh
+++ b/input/fsh/ehealth-clinicalimpression.fsh
@@ -8,7 +8,8 @@ Parent: ClinicalImpression
 * extension contains ehealth-clinicalimpression-decision named decision 0..*
 * extension contains http://hl7.org/fhir/StructureDefinition/workflow-episodeOfCare named episodeOfCare 1..1
 * extension contains ehealth-questionnaireresponse-finding-basis named findingBasis 0..*
-* extension[episodeOfCare].valueReference only Reference(EpisodeOfCare)
+* extension[episodeOfCare].valueReference only Reference(ehealth-episodeofcare)
+* extension[episodeOfCare].valueReference 1..1
 * extension[episodeOfCare] ^type.aggregation = #referenced
 * code 1..1
 * code from http://ehealth.sundhed.dk/vs/clinicalimpression-codes

--- a/input/fsh/ehealth-clinicalimpression.fsh
+++ b/input/fsh/ehealth-clinicalimpression.fsh
@@ -6,8 +6,10 @@ Parent: ClinicalImpression
 * extension contains ehealth-clinicalimpression-careplan named carePlan 0..1
 * extension contains ehealth-clinicalimpression-decisionContext named decisionContext 0..*
 * extension contains ehealth-clinicalimpression-decision named decision 0..*
-* extension contains http://hl7.org/fhir/StructureDefinition/workflow-episodeOfCare|4.0.1 named episodeOfCare 1..1
+* extension contains http://hl7.org/fhir/StructureDefinition/workflow-episodeOfCare named episodeOfCare 1..1
 * extension contains ehealth-questionnaireresponse-finding-basis named findingBasis 0..*
+* extension[episodeOfCare].valueReference only Reference(ehealth-episodeofcare)
+* extension[episodeOfCare].valueReference 1..1
 * extension[episodeOfCare] ^type.aggregation = #referenced
 * code 1..1
 * code from http://ehealth.sundhed.dk/vs/clinicalimpression-codes

--- a/input/fsh/ehealth-clinicalimpression.fsh
+++ b/input/fsh/ehealth-clinicalimpression.fsh
@@ -10,7 +10,7 @@ Parent: ClinicalImpression
 * extension contains ehealth-questionnaireresponse-finding-basis named findingBasis 0..*
 * extension[episodeOfCare].valueReference only Reference(ehealth-episodeofcare)
 * extension[episodeOfCare].valueReference 1..1
-* extension[episodeOfCare] ^type.aggregation = #referenced
+* extension[episodeOfCare].valueReference ^type.aggregation = #referenced
 * code 1..1
 * code from http://ehealth.sundhed.dk/vs/clinicalimpression-codes
 * subject only Reference(ehealth-patient)

--- a/input/fsh/ehealth-clinicalimpression.fsh
+++ b/input/fsh/ehealth-clinicalimpression.fsh
@@ -6,11 +6,9 @@ Parent: ClinicalImpression
 * extension contains ehealth-clinicalimpression-careplan named carePlan 0..1
 * extension contains ehealth-clinicalimpression-decisionContext named decisionContext 0..*
 * extension contains ehealth-clinicalimpression-decision named decision 0..*
-* extension contains http://hl7.org/fhir/StructureDefinition/workflow-episodeOfCare named episodeOfCare 1..1
+* extension contains http://hl7.org/fhir/StructureDefinition/workflow-episodeOfCare|4.0.1 named episodeOfCare 1..1
 * extension contains ehealth-questionnaireresponse-finding-basis named findingBasis 0..*
-* extension[episodeOfCare].valueReference only Reference(ehealth-episodeofcare)
-* extension[episodeOfCare].valueReference 1..1
-* extension[episodeOfCare].valueReference ^type.aggregation = #referenced
+* extension[episodeOfCare] ^type.aggregation = #referenced
 * code 1..1
 * code from http://ehealth.sundhed.dk/vs/clinicalimpression-codes
 * subject only Reference(ehealth-patient)

--- a/input/fsh/ehealth-clinicalimpression.fsh
+++ b/input/fsh/ehealth-clinicalimpression.fsh
@@ -6,7 +6,7 @@ Parent: ClinicalImpression
 * extension contains ehealth-clinicalimpression-careplan named carePlan 0..1
 * extension contains ehealth-clinicalimpression-decisionContext named decisionContext 0..*
 * extension contains ehealth-clinicalimpression-decision named decision 0..*
-* extension contains http://hl7.org/fhir/StructureDefinition/workflow-episodeOfCare named episodeOfCare 1..1
+* extension contains http://hl7.org/fhir/StructureDefinition/workflow-episodeOfCare|4.0.1 named episodeOfCare 1..1
 * extension contains ehealth-questionnaireresponse-finding-basis named findingBasis 0..*
 * extension[episodeOfCare] ^type.aggregation = #referenced
 * code 1..1

--- a/input/fsh/ehealth-clinicalimpression.fsh
+++ b/input/fsh/ehealth-clinicalimpression.fsh
@@ -6,8 +6,9 @@ Parent: ClinicalImpression
 * extension contains ehealth-clinicalimpression-careplan named carePlan 0..1
 * extension contains ehealth-clinicalimpression-decisionContext named decisionContext 0..*
 * extension contains ehealth-clinicalimpression-decision named decision 0..*
-* extension contains http://hl7.org/fhir/StructureDefinition/workflow-episodeOfCare|4.0.1 named episodeOfCare 1..1
+* extension contains http://hl7.org/fhir/StructureDefinition/workflow-episodeOfCare named episodeOfCare 1..1
 * extension contains ehealth-questionnaireresponse-finding-basis named findingBasis 0..*
+* extension[episodeOfCare].valueReference only Reference(EpisodeOfCare)
 * extension[episodeOfCare] ^type.aggregation = #referenced
 * code 1..1
 * code from http://ehealth.sundhed.dk/vs/clinicalimpression-codes


### PR DESCRIPTION
- [x] I have ensured the target branch is correct; for new changes, they target e.g. `release-3.5.0`. Only release branches should target `master`. For more details, see [here](../RELEASE.md).

The IG is materialised as a website automatically by CI, and can be found [here](http://build.fhir.org/ig/fut-infrastructure/implementation-guide/branches/).