### PR TITLE
[FUT1-20311] FUT1-20311 - new profile added for Ehealth material comm…

### DIFF
--- a/input/fsh/ehealth-careplan.fsh
+++ b/input/fsh/ehealth-careplan.fsh
@@ -54,6 +54,7 @@ Parent: CarePlan
 * note.authorReference only Reference(ehealth-practitioner or ehealth-patient or ehealth-relatedperson)
 * note.authorString only string
 * extension contains ehealth-participant named participant 0..*
+* extension[participant].extension[function].value[x] from "http://ehealth.sundhed.dk/vs/participant-function" (required)
 
 Extension:   ehealth-careplan-statusHistory
 Title:       "Careplan status history"

--- a/input/fsh/ehealth-episodeofcare.fsh
+++ b/input/fsh/ehealth-episodeofcare.fsh
@@ -6,6 +6,7 @@ Parent: EpisodeOfCare
 * extension contains ehealth-episodeofcare-statusschedule named episodeofcareStatusschedule 0..*
 * extension contains ehealth-teamschedule named teamschedule 0..*
 * extension contains ehealth-participant named participant 0..*
+* extension[participant].extension[function].value[x] from "http://ehealth.sundhed.dk/vs/participant-function" (required)
 * diagnosis 1..*
 * diagnosis.condition only Reference(ehealth-condition)
 * diagnosis.condition ^type.aggregation = #referenced

--- a/input/fsh/ehealth-ext-participant.fsh
+++ b/input/fsh/ehealth-ext-participant.fsh
@@ -7,7 +7,6 @@ Description: "The participating CareTeam or Practitioner."
     actor 0..1 and
     actorref 0..1
 * extension[function].value[x] only Coding
-* extension[function].value[x] from http://ehealth.sundhed.dk/vs/participant-function (required)
 * extension[function].valueCoding 0..1
 * extension[function] ^short = "The function of the participant"
 * extension[function] ^definition = "The code defining the function of the participant."

--- a/input/fsh/ehealth-material-communication.fsh
+++ b/input/fsh/ehealth-material-communication.fsh
@@ -1,0 +1,19 @@
+Profile: ehealth-material-communication
+Id: ehealth-material-communication
+Parent: ehealth-communication
+* recepient only Reference(Patient)
+* recepient ^type.aggregation = #referenced
+* payload.contentReference 1..1
+* payload.contentRefence only Reference(DocumentReference)
+* payload.contentReference ^type.aggregation = #referenced
+* category 1..*
+* category from hhttp://ehealth.sundhed.dk/cs/material-communication-category
+* extension contains ehealth-participant named participant 1..1
+* extension[participant].extension[function].value[x] from "http://ehealth.sundhed.dk/vs/material-assignment-participant-function" (required)
+
+Extension: ehealth-period
+Title:     "Period"
+Description: "Specifies the temporal validity of an material communication instance. Contains a period, eg. specifying temporal validity"
+* . ^short = "Specifies the temporal validity of an material communication instance"
+* value[x] only Period
+* valuePeriod 1..1


### PR DESCRIPTION
- [X] I have ensured the target branch is correct; for new changes, they target e.g. `release-3.5.0`. Only release branches should target `master`. For more details, see [here](../RELEASE.md).

The IG is materialised as a website automatically by CI, and can be found [here](http://build.fhir.org/ig/fut-infrastructure/implementation-guide/branches/).