### PR TITLE
Add 3 new ClinicalImpression.findingCodes to CodeSystem and include i…

### DIFF
--- a/input/resources/CodeSystem-ehealth-clinicalimpression-decision-support-codes.json
+++ b/input/resources/CodeSystem-ehealth-clinicalimpression-decision-support-codes.json
@@ -1,6 +1,7 @@
 {
   "resourceType": "CodeSystem",
   "url": "http://ehealth.sundhed.dk/cs/clinicalimpression-decision-support-codes",
+  "id": "clinicalimpression-decision-support-codes",
   "version": "1.0.0",
   "name": "ClinicalImpressionDecisionSupportCodes",
   "title": "ClinicalImpression Decision Support Codes",

--- a/input/resources/CodeSystem-ehealth-clinicalimpression-decision-support-codes.json
+++ b/input/resources/CodeSystem-ehealth-clinicalimpression-decision-support-codes.json
@@ -1,0 +1,59 @@
+{
+  "resourceType": "CodeSystem",
+  "url": "http://ehealth.sundhed.dk/cs/clinicalimpression-decision-support-codes",
+  "version": "1.0.0",
+  "name": "ClinicalImpressionDecisionSupportCodes",
+  "title": "ClinicalImpression Decision Support Codes",
+  "status": "active",
+  "experimental": false,
+  "date": "2025-09-08T00:00:00+00:00",
+  "publisher": "Region Nordjylland, Telma forvaltning",
+  "contact": [
+    {
+      "telecom": [
+        {
+          "system": "email",
+          "value": "telmaforvaltning@rn.dk"
+        }
+      ]
+    }
+  ],
+  "description": "Decision support codes",
+  "caseSensitive": true,
+  "content": "complete",
+  "concept": [
+    {
+      "code": "deviation-found",
+      "display": "Deviation found",
+      "definition": "Deviation found suggesting possible deterioration of condition",
+      "designation": [
+        {
+          "language": "da",
+          "value": "Der er fundet afvigelse, der tyder på at borgeren vil opleve forværring af sygdom eller tilstand"
+        }
+      ]
+    },
+    {
+      "code": "no-deviation-found",
+      "display": "No deviation found",
+      "definition": "No deviation found suggesting possible deterioration of condition",
+      "designation": [
+        {
+          "language": "da",
+          "value": " Der er ikke fundet afvigelse, der tyder på at borgeren vil opleve forværring af sygdom eller tilstand"
+        }
+      ]
+    },
+    {
+      "code": "insufficient-data",
+      "display": "Insufficient data",
+      "definition": "Insufficient data for determining deviation suggesting possible deterioration of condition",
+      "designation": [
+        {
+          "language": "da",
+          "value": "Utilstrækkelige data forhindrer bestemmelse af afvigelse, der tyder på at borgeren vil opleve forværring af sygdom eller tilstand"
+        }
+      ]
+    }
+  ]
+}

--- a/input/resources/CodeSystem-ehealth-clinicalimpression-decision-support-codes.json
+++ b/input/resources/CodeSystem-ehealth-clinicalimpression-decision-support-codes.json
@@ -40,7 +40,7 @@
       "designation": [
         {
           "language": "da",
-          "value": " Der er ikke fundet afvigelse, der tyder på at borgeren vil opleve forværring af sygdom eller tilstand"
+          "value": "Der er ikke fundet afvigelse, der tyder på at borgeren vil opleve forværring af sygdom eller tilstand"
         }
       ]
     },

--- a/input/resources/ValueSet-ehealth-clinicalimpression-finding-codes.json
+++ b/input/resources/ValueSet-ehealth-clinicalimpression-finding-codes.json
@@ -185,6 +185,44 @@
             ]
           }
         ]
+      },
+      {
+        "system": "http://ehealth.sundhed.dk/cs/clinicalimpression-decision-support-codes",
+        "concept": [
+          {
+            "code": "deviation-found",
+            "display": "Deviation found",
+            "definition": "Deviation found suggesting possible deterioration of condition",
+            "designation": [
+              {
+                "language": "da",
+                "value": "Der er fundet afvigelse, der tyder på at borgeren vil opleve forværring af sygdom eller tilstand"
+              }
+            ]
+          },
+          {
+            "code": "no-deviation-found",
+            "display": "No deviation found",
+            "definition": "No deviation found suggesting possible deterioration of condition",
+            "designation": [
+              {
+                "language": "da",
+                "value": " Der er ikke fundet afvigelse, der tyder på at borgeren vil opleve forværring af sygdom eller tilstand"
+              }
+            ]
+          },
+          {
+            "code": "insufficient-data",
+            "display": "Insufficient data",
+            "definition": "Insufficient data for determining deviation suggesting possible deterioration of condition",
+            "designation": [
+              {
+                "language": "da",
+                "value": "Utilstrækkelige data forhindrer bestemmelse af afvigelse, der tyder på at borgeren vil opleve forværring af sygdom eller tilstand"
+              }
+            ]
+          }
+        ]
       }
     ]
   }

--- a/input/resources/ValueSet-ehealth-clinicalimpression-finding-codes.json
+++ b/input/resources/ValueSet-ehealth-clinicalimpression-finding-codes.json
@@ -207,7 +207,7 @@
             "designation": [
               {
                 "language": "da",
-                "value": " Der er ikke fundet afvigelse, der tyder på at borgeren vil opleve forværring af sygdom eller tilstand"
+                "value": "Der er ikke fundet afvigelse, der tyder på at borgeren vil opleve forværring af sygdom eller tilstand"
               }
             ]
           },


### PR DESCRIPTION
Add new CodeSystem and 3 codes:
`http://ehealth.sundhed.dk/cs/clinicalimpression-decision-support-codes`

And include these codes in ValueSet:
`ehealth-clinicalimpression-finding-codes`

- [x] I have ensured the target branch is correct; for new changes, they target e.g. `release-3.5.0`. Only release branches should target `master`. For more details, see [here](../RELEASE.md).

The IG is materialised as a website automatically by CI, and can be found [here](http://build.fhir.org/ig/fut-infrastructure/implementation-guide/branches/).