### PR TITLE
fix: update idempotent to affectsState for import and upload operations

### DIFF
--- a/input/resources/OperationDefinition--s-import.json
+++ b/input/resources/OperationDefinition--s-import.json
@@ -7,7 +7,7 @@
   "kind": "operation",
   "date": "2021-05-06T08:31:20+00:00",
   "description": "Import terminology resources",
-  "idempotent": false,
+  "affectsState": true,
   "code": "import",
   "system": true,
   "type": false,

--- a/input/resources/OperationDefinition--s-upload-external-code-system.json
+++ b/input/resources/OperationDefinition--s-upload-external-code-system.json
@@ -6,7 +6,7 @@
   "status": "active",
   "kind": "operation",
   "date": "2021-05-06T08:31:20+00:00",
-  "idempotent": false,
+  "affectsState": true,
   "code": "upload-external-code-system",
   "system": true,
   "type": false,


### PR DESCRIPTION
- [x] I have ensured the target branch is correct; for new changes, they target e.g. `release-3.5.0`. Only release branches should target `master`. For more details, see [here](../RELEASE.md).

The IG is materialised as a website automatically by CI, and can be found [here](http://build.fhir.org/ig/fut-infrastructure/implementation-guide/branches/).