### PR TITLE
fix: pin ig-publisher to 2.0.15 for the time being to handle canonica…

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Transpile IG
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
-    container: ghcr.io/trifork/ig-publisher:latest
+    container: ghcr.io/trifork/ig-publisher:2.0.15
 
     steps:
       # Checkout the repos needed
@@ -40,7 +40,7 @@ jobs:
     # A release is defined as a tag pushed to main
     if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
     runs-on: ubuntu-latest
-    container: ghcr.io/trifork/ig-publisher:latest
+    container: ghcr.io/trifork/ig-publisher:2.0.15
 
     steps:
       # Checkout the repos needed


### PR DESCRIPTION
…l URLs

- [ ] I have ensured the target branch is correct; for new changes, they target e.g. `release-3.5.0`. Only release branches should target `master`. For more details, see [here](../RELEASE.md).

The IG is materialised as a website automatically by CI, and can be found [here](http://build.fhir.org/ig/fut-infrastructure/implementation-guide/branches/).