### PR TITLE
Restrict payload to cardinality 1..1 in materialCommunication

### DIFF
--- a/input/fsh/ehealth-material-communication.fsh
+++ b/input/fsh/ehealth-material-communication.fsh
@@ -5,6 +5,7 @@ Parent: Communication
 * recipient only Reference(Patient)
 * recipient ^type.aggregation = #referenced
 * recipient 0..1
+* payload 1..1
 * payload.content[x] only Reference(DocumentReference)
 * payload.content[x] 1..1
 * payload.content[x] ^type.aggregation = #referenced

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -10,6 +10,7 @@ This is the log of changes made to the eHealth Implementation Guide.
 ### ConceptMaps
 ### Resource/profile changes
 - Added extention ehealth-reference-careplan to Task
+- BREAKING: Limited MaterialCommunication.payload cardinality to 1..1
 
 ### Search parameters
 - Added search parameter `carePlan` on `ehealth-task` to be able to query by CarePlan


### PR DESCRIPTION
- [ ] I have ensured the target branch is correct; for new changes, they target e.g. `release-3.5.0`. Only release branches should target `master`. For more details, see [here](../RELEASE.md).

The IG is materialised as a website automatically by CI, and can be found [here](http://build.fhir.org/ig/fut-infrastructure/implementation-guide/branches/).