### PR TITLE
FUT1-21933 Add affiliation extension to Consent.

### DIFF
--- a/input/fsh/ehealth-consent.fsh
+++ b/input/fsh/ehealth-consent.fsh
@@ -11,3 +11,12 @@ Parent: Consent
 * organization only Reference(ehealth-organization)
 * organization ^type.aggregation = #referenced
 * sourceReference only Reference(ehealth-consent or ehealth-documentreference or Contract or ehealth-questionnaireresponse)
+* extension contains ehealth-consent-affiliation named affiliation 0..*
+
+Extension: ehealth-consent-affiliation
+Title:     "Affiliation to EpisodeOfCare and optionally CarePlan"
+Description: "Affiliation to EpisodeOfCare and optionally CarePlan"
+* . ^short = "Affiliation to EpisodeOfCare and optionally CarePlan"
+* value[x] only Reference(ehealth-episodeofcare or ehealth-careplan)
+* valueReference 1..1
+* value[x] ^type.aggregation = #referenced


### PR DESCRIPTION
Add affiliation extension to consent.

- [ ] I have ensured the target branch is correct; for new changes, they target e.g. `release-3.5.0`. Only release branches should target `master`. For more details, see [here](../RELEASE.md).

The IG is materialised as a website automatically by CI, and can be found [here](http://build.fhir.org/ig/fut-infrastructure/implementation-guide/branches/).