### PR TITLE
FUT1-22151 upgrade to hapi-fhir 8.6.1

### DIFF
--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -8,6 +8,7 @@ This is the log of changes made to the eHealth Implementation Guide.
 ### Code systems
 ### ValueSets
 ### ConceptMaps
+- Updated ConceptMap http://ehealth.sundhed.dk/ConceptMap/activitydefinition-code-to-measurement-resource-type to target http://hl7.org/fhir/ValueSet/resource-types instead of http://hl7.org/fhir/resource-types
 ### Resource/profile changes
 
 ## 8.0.0 (2026-02-04)

--- a/input/resources/ConceptMap-ehealth.sundhed.dk-ConceptMap-activitydefinition-code-to-measurement-resource-type.json
+++ b/input/resources/ConceptMap-ehealth.sundhed.dk-ConceptMap-activitydefinition-code-to-measurement-resource-type.json
@@ -22,7 +22,7 @@
     }
   ],
   "sourceUri": "http://ehealth.sundhed.dk/vs/activitydefinition-code",
-  "targetUri": "http://hl7.org/fhir/resource-types",
+  "targetUri": "http://hl7.org/fhir/ValueSet/resource-types",
   "group": [
     {
       "source": "http://ehealth.sundhed.dk/cs/activitydefinition-code",


### PR DESCRIPTION
- [ ] I have ensured the target branch is correct; for new changes, they target e.g. `release-3.5.0`. Only release branches should target `master`. For more details, see [here](../RELEASE.md).

The IG is materialised as a website automatically by CI, and can be found [here](http://build.fhir.org/ig/fut-infrastructure/implementation-guide/branches/).