### PR TITLE
fix(ig): Remove display values from ValueSets

### DIFF
--- a/input/resources/ValueSet-ehealth-activitydefinition-code.json
+++ b/input/resources/ValueSet-ehealth-activitydefinition-code.json
@@ -36,26 +36,16 @@
         "system": "http://snomed.info/sct",
         "concept": [
           {
-            "code": "445988008",
-            "display": "Assessment using health assessment questionnaire (procedure)",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Assessment using health assessment questionnaire (procedure)"
-              }
-            ]
+            "code": "445988008"
           },
           {
-            "code": "229057006",
-            "display": "Meetings (procedure)"
+            "code": "229057006"
           },
           {
-            "code": "273586006",
-            "display": "Master questionnaire"
+            "code": "273586006"
           },
           {
-            "code": "409073007",
-            "display": "Instruction"
+            "code": "409073007"
           }
         ]
       },
@@ -63,12 +53,10 @@
         "system": "urn:oid:1.2.208.176.2.4",
         "concept": [
           {
-            "code": "ALCA00",
-            "display": "fysisk fremmøde"
+            "code": "ALCA00"
           },
           {
-            "code": "ALCA03",
-            "display": "virtuel kontakt"
+            "code": "ALCA03"
           }
         ]
       }

--- a/input/resources/ValueSet-ehealth-clinicalimpression-finding-codes.json
+++ b/input/resources/ValueSet-ehealth-clinicalimpression-finding-codes.json
@@ -35,104 +35,34 @@
         "system": "http://snomed.info/sct",
         "concept": [
           {
-            "code": "281300000",
-            "display": "Below reference range",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Below reference range"
-              }
-            ]
+            "code": "281300000"
           },
           {
-            "code": "281302008",
-            "display": "Above reference range",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Above reference range"
-              }
-            ]
+            "code": "281302008"
           },
           {
-            "code": "281301001",
-            "display": "Within reference range",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Within reference range"
-              }
-            ]
+            "code": "281301001"
           },
           {
-            "code": "394844007",
-            "display": "Outside reference range",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Outside reference range"
-              }
-            ]
+            "code": "394844007"
           },
           {
-            "code": "442686002",
-            "display": "Measurement finding below reference range",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Measurement finding below reference range"
-              }
-            ]
+            "code": "442686002"
           },
           {
-            "code": "442756004",
-            "display": "Measurement finding above reference range",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Measurement finding above reference range"
-              }
-            ]
+            "code": "442756004"
           },
           {
-            "code": "442082004",
-            "display": "Measurement finding within reference range",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Measurement finding within reference range"
-              }
-            ]
+            "code": "442082004"
           },
           {
-            "code": "442096005",
-            "display": "Measurement finding outside reference range",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Measurement finding outside reference range"
-              }
-            ]
+            "code": "442096005"
           },
           {
-            "code": "449171008",
-            "display": "Oxygen saturation below reference range",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Oxygen saturation below reference range"
-              }
-            ]
+            "code": "449171008"
           },
           {
-            "code": "448225001",
-            "display": "Oxygen saturation within reference range",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Oxygen saturation within reference range"
-              }
-            ]
+            "code": "448225001"
           }
         ]
       },
@@ -140,24 +70,10 @@
         "system": "urn:oid:1.2.208.184.100.1",
         "concept": [
           {
-            "code": "RAL",
-            "display": "Terapeutiske grænseværdier for RØD alarm",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Terapeutiske grænseværdier for RØD alarm"
-              }
-            ]
+            "code": "RAL"
           },
           {
-            "code": "GAL",
-            "display": "Terapeutiske grænseværdier for GUL alarm",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Terapeutiske grænseværdier for GUL alarm"
-              }
-            ]
+            "code": "GAL"
           }
         ]
       },
@@ -165,24 +81,10 @@
         "system": "http://ehealth.sundhed.dk/cs/reference-range-type",
         "concept": [
           {
-            "code": "RELRAL",
-            "display": "Terapeutic relative reference range for RED alarm",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Terapeutiske relative grænseværdier for RØD alarm"
-              }
-            ]
+            "code": "RELRAL"
           },
           {
-            "code": "RELGAL",
-            "display": "Terapeutic relative reference range for YELLOW alarm",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Terapeutiske relative grænseværdier for GUL alarm"
-              }
-            ]
+            "code": "RELGAL"
           }
         ]
       },

--- a/input/resources/ValueSet-ehealth-conditions.json
+++ b/input/resources/ValueSet-ehealth-conditions.json
@@ -27,134 +27,126 @@
         "system": "urn:oid:1.2.208.176.2.4",
         "concept": [
           {
-            "code": "ALAL03",
-            "display": "Psykiske lidelser og adfærdsmæssige forstyrrelser"
+            "code": "ALAL03"
           },
           {
-            "code": "DE10",
-            "display": "Type 1-diabetes"
+            "code": "DE10"
           },
           {
-            "code": "DE11",
-            "display": "Type 2-diabetes"
+            "code": "DE11"
           },
           {
-            "code": "DF00",
-            "display": "Demens ved Alzheimers sygdom"
+            "code": "DF00"
           },
           {
-            "code": "DF10",
-            "display": "Psykiske lidelser og adfærdsmæssige forstyrrelser forårsaget af brug af alkohol"
+            "code": "DF10"
           },
           {
-            "code": "DF20",
-            "display": "Skizofreni"
+            "code": "DF20"
           },
           {
-            "code": "DF30",
-            "display": "Manisk enkeltepisode"
+            "code": "DF30"
           },
           {
-            "code": "DF40",
-            "display": "Fobiske angsttilstande"
+            "code": "DF40"
           },
           {
-            "code": "DF50",
-            "display": "Spiseforstyrrelser"
+            "code": "DF50"
           },
           {
-            "code": "DF60",
-            "display": "Specifikke forstyrrelser af personlighedsstrukturen"
+            "code": "DF60"
           },
           {
-            "code": "DF70",
-            "display": "Mental retardering af lettere grad"
+            "code": "DF70"
           },
           {
-            "code": "DF80",
-            "display": "Specifikke udviklingsforstyrrelser af tale og sprog"
+            "code": "DF80"
           },
           {
-            "code": "DF90",
-            "display": "Hyperkinetiske forstyrrelser"
+            "code": "DF90"
           },
           {
-            "code": "DF99",
-            "display": "Ikke nærmere specificerede psykiske lidelser"
+            "code": "DF99"
           },
           {
-            "code": "DG20",
-            "display": "Parkinsons sygdom"
+            "code": "DG20"
           },
           {
-            "code": "DJ44",
-            "display": "Kronisk obstruktiv lungesygdom"
+            "code": "DJ44"
           },
           {
-            "code": "DI20",
-            "display": "Angina pectoris"
+            "code": "DI20"
           },
           {
-            "code": "DI25",
-            "display": "Kronisk iskæmisk hjertesygdom"
+            "code": "DI25"
           },
           {
-            "code": "DI50",
-            "display": "Hjertesvigt"
+            "code": "DI50"
           },
           {
-            "code": "DZ76",
-            "display": "Personer i kontakt med sundhedsvæsenet af andre årsager"
+            "code": "DZ76"
           }
         ]
       },
       {
         "system": "http://kl.dk/fhir/common/caresocial/CodeSystem/FSIII",
-        "filter": [ {
-          "property": "concept",
-          "op": "is-a",
-          "value": "F"
-        } ]
+        "filter": [
+          {
+            "property": "concept",
+            "op": "is-a",
+            "value": "F"
+          }
+        ]
       },
       {
         "system": "http://kl.dk/fhir/common/caresocial/CodeSystem/FSIII",
-        "filter": [ {
-          "property": "concept",
-          "op": "is-a",
-          "value": "J1"
-        } ]
+        "filter": [
+          {
+            "property": "concept",
+            "op": "is-a",
+            "value": "J1"
+          }
+        ]
       },
       {
         "system": "http://kl.dk/fhir/common/caresocial/CodeSystem/FSIII",
-        "filter": [ {
-          "property": "concept",
-          "op": "is-a",
-          "value": "J2"
-        } ]
+        "filter": [
+          {
+            "property": "concept",
+            "op": "is-a",
+            "value": "J2"
+          }
+        ]
       },
       {
         "system": "http://kl.dk/fhir/common/caresocial/CodeSystem/FSIII",
-        "filter": [ {
-          "property": "concept",
-          "op": "is-a",
-          "value": "J3"
-        } ]
+        "filter": [
+          {
+            "property": "concept",
+            "op": "is-a",
+            "value": "J3"
+          }
+        ]
       },
       {
         "system": "http://kl.dk/fhir/common/caresocial/CodeSystem/FSIII",
-        "filter": [ {
-          "property": "concept",
-          "op": "is-a",
-          "value": "J4"
-        } ]
+        "filter": [
+          {
+            "property": "concept",
+            "op": "is-a",
+            "value": "J4"
+          }
+        ]
       },
       {
         "system": "http://kl.dk/fhir/common/caresocial/CodeSystem/FSIII",
-        "filter": [ {
-          "property": "concept",
-          "op": "is-a",
-          "value": "J5"
-        } ]
+        "filter": [
+          {
+            "property": "concept",
+            "op": "is-a",
+            "value": "J5"
+          }
+        ]
       }
     ]
   }

--- a/input/resources/ValueSet-ehealth-device-measurement-unit.json
+++ b/input/resources/ValueSet-ehealth-device-measurement-unit.json
@@ -27,46 +27,13 @@
         "system": "urn:oid:1.2.208.176.2.1",
         "concept": [
           {
-            "code": "NPU03011",
-            "display": "Hb(Fe; O2-bind.; aB)—Oxygen(O2); mætn. = ?",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Oxygen saturation"
-              },
-              {
-                "language": "da",
-                "value": "Hb(Fe; O2-bind.; aB)—Oxygen(O2); mætn. = ?"
-              }
-            ]
+            "code": "NPU03011"
           },
           {
-            "code": "NPU21692",
-            "display": "Hjerte—Systole; frekv. = ? × 1/min",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Heartbeats per minute"
-              },
-              {
-                "language": "da",
-                "value": "Hjerte—Systole; frekv. = ? × 1/min"
-              }
-            ]
+            "code": "NPU21692"
           },
           {
-            "code": "NPU03804",
-            "display": "Pt—Legeme; masse = ? kg",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Weight in kilogrammes"
-              },
-              {
-                "language": "da",
-                "value": "Pt—Legeme; masse = ? kg"
-              }
-            ]
+            "code": "NPU03804"
           }
         ]
       }

--- a/input/resources/ValueSet-ehealth-device-types.json
+++ b/input/resources/ValueSet-ehealth-device-types.json
@@ -27,22 +27,13 @@
         "system": "http://snomed.info/sct",
         "concept": [
           {
-            "code": "59181002",
-            "display": "Oxygen analyser",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Oxygen analyser"
-              }
-            ]
+            "code": "59181002"
           },
           {
-            "code": "258057004",
-            "display": "ikke-invasiv blodtryksmonitor"
+            "code": "258057004"
           },
           {
-            "code": "19892000",
-            "display": "Vægt"
+            "code": "19892000"
           }
         ]
       }

--- a/input/resources/ValueSet-ehealth-document-class.json
+++ b/input/resources/ValueSet-ehealth-document-class.json
@@ -32,14 +32,7 @@
         "system": "http://snomed.info/sct",
         "concept": [
           {
-            "code": "900000000000469006",
-            "display": "URL",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Hyperlink"
-              }
-            ]
+            "code": "900000000000469006"
           }
         ]
       }

--- a/input/resources/ValueSet-ehealth-document-type.json
+++ b/input/resources/ValueSet-ehealth-document-type.json
@@ -32,24 +32,10 @@
         "system": "http://loinc.org",
         "concept": [
           {
-            "code": "69730-0",
-            "display": "Instructions",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Instruktioner"
-              }
-            ]
+            "code": "69730-0"
           },
           {
-            "code": "48766-0",
-            "display": "Information source",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Informationskilde"
-              }
-            ]
+            "code": "48766-0"
           }
         ]
       }

--- a/input/resources/ValueSet-ehealth-facility-type-codes.json
+++ b/input/resources/ValueSet-ehealth-facility-type-codes.json
@@ -30,414 +30,127 @@
         "system": "http://snomed.info/sct/554471000005108/version/20150731",
         "concept": [
           {
-            "code": "554221000005108",
-            "display": "Dwilling place",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Dwilling place"
-              }
-            ]
+            "code": "554221000005108"
           },
           {
-            "code": "546821000005103",
-            "display": "Occupational therapy clinic",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Occupational therapy clinic"
-              }
-            ]
+            "code": "546821000005103"
           },
           {
-            "code": "547011000005103",
-            "display": "Physiotherapy clinic",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Physiotherapy clinic"
-              }
-            ]
+            "code": "547011000005103"
           },
           {
-            "code": "546811000005109",
-            "display": "Rehabilitation center",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Rehabilitation center"
-              }
-            ]
+            "code": "546811000005109"
           },
           {
-            "code": "550621000005101",
-            "display": "District nursing",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "District nursing"
-              }
-            ]
+            "code": "550621000005101"
           },
           {
-            "code": "550631000005103",
-            "display": "Midwife clinic",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Midwife clinic"
-              }
-            ]
+            "code": "550631000005103"
           },
           {
-            "code": "550641000005106",
-            "display": "Chiropractic clinic",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Chiropractic clinic"
-              }
-            ]
+            "code": "550641000005106"
           },
           {
-            "code": "550651000005108",
-            "display": "Medical laboratory",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Medical laboratory"
-              }
-            ]
+            "code": "550651000005108"
           },
           {
-            "code": "550661000005105",
-            "display": "Emergency medical service",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Emergency medical service"
-              }
-            ]
+            "code": "550661000005105"
           },
           {
-            "code": "554211000005102",
-            "display": "Prehospital unit",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Prehospital unit"
-              }
-            ]
+            "code": "554211000005102"
           },
           {
-            "code": "550711000005101",
-            "display": "Psychological counseling clinic",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Psychological counseling clinic"
-              }
-            ]
+            "code": "550711000005101"
           },
           {
-            "code": "550671000005100",
-            "display": "Medical specialist practice site",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Medical specialist practice site"
-              }
-            ]
+            "code": "550671000005100"
           },
           {
-            "code": "554061000005105",
-            "display": "Chiropodist clinic",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Chiropodist clinic"
-              }
-            ]
+            "code": "554061000005105"
           },
           {
-            "code": "554041000005106",
-            "display": "Health administration",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Health administration"
-              }
-            ]
+            "code": "554041000005106"
           },
           {
-            "code": "554021000005101",
-            "display": "Health visitors",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Health visitors"
-              }
-            ]
+            "code": "554021000005101"
           },
           {
-            "code": "550681000005102",
-            "display": "dental practice",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Dental practice"
-              }
-            ]
+            "code": "550681000005102"
           },
           {
-            "code": "550691000005104",
-            "display": "Dental care clinic",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Dental care clinic"
-              }
-            ]
+            "code": "550691000005104"
           },
           {
-            "code": "550701000005104",
-            "display": "Dental technician clinic",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Dental technician clinic"
-              }
-            ]
+            "code": "550701000005104"
           },
           {
-            "code": "554231000005106",
-            "display": "Vaccination clinic",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Vaccination clinic"
-              }
-            ]
+            "code": "554231000005106"
           },
           {
-            "code": "554051000005108",
-            "display": "Reflexology clinic",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Reflexology clinic"
-              }
-            ]
+            "code": "554051000005108"
           },
           {
-            "code": "550811000005108",
-            "display": "Administrative unit",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Administrative unit"
-              }
-            ]
+            "code": "550811000005108"
           },
           {
-            "code": "547211000005108",
-            "display": "Municipality",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Municipality"
-              }
-            ]
+            "code": "547211000005108"
           },
           {
-            "code": "550891000005100",
-            "display": "Private",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Private"
-              }
-            ]
+            "code": "550891000005100"
           },
           {
-            "code": "550881000005103",
-            "display": "Region",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Region"
-              }
-            ]
+            "code": "550881000005103"
           },
           {
-            "code": "550411000005105",
-            "display": "Other health institution",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Other health institution"
-              }
-            ]
+            "code": "550411000005105"
           },
           {
-            "code": "554851000005102",
-            "display": "Asylum centre",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Asylum centre"
-              }
-            ]
+            "code": "554851000005102"
           },
           {
-            "code": "550861000005106",
-            "display": "Physiotherapy and occupational clinic",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Physiotherapy and occupational clinic"
-              }
-            ]
+            "code": "550861000005106"
           },
           {
-            "code": "554881000005108",
-            "display": "Handicap and psychiatry",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Handicap and psychiatry"
-              }
-            ]
+            "code": "554881000005108"
           },
           {
-            "code": "554861000005100",
-            "display": "Handicap",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Handicap"
-              }
-            ]
+            "code": "554861000005100"
           },
           {
-            "code": "554821000005109",
-            "display": "Home care",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Home care"
-              }
-            ]
+            "code": "554821000005109"
           },
           {
-            "code": "554411000005101",
-            "display": "Employment agency",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Employment agency"
-              }
-            ]
+            "code": "554411000005101"
           },
           {
-            "code": "554871000005105",
-            "display": "Psychiatry",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Psychiatry"
-              }
-            ]
+            "code": "554871000005105"
           },
           {
-            "code": "550821000005102",
-            "display": "Service unit",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Service unit"
-              }
-            ]
+            "code": "550821000005102"
           },
           {
-            "code": "550871000005101",
-            "display": "Emergency admission unit",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Emergency admission unit"
-              }
-            ]
+            "code": "550871000005101"
           },
           {
-            "code": "554241000005103",
-            "display": "Technical location number",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Technical location number"
-              }
-            ]
+            "code": "554241000005103"
           },
           {
-            "code": "550841000005107",
-            "display": "Research unit",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Research unit"
-              }
-            ]
+            "code": "550841000005107"
           },
           {
-            "code": "550851000005109",
-            "display": "Clinical unit",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Clinical unit"
-              }
-            ]
+            "code": "550851000005109"
           },
           {
-            "code": "551611000005102",
-            "display": "Surgical ward",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Surgical ward"
-              }
-            ]
+            "code": "551611000005102"
           },
           {
-            "code": "554071000005100",
-            "display": "Hospital pharmacy",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Hospital pharmacy"
-              }
-            ]
+            "code": "554071000005100"
           },
           {
-            "code": "550831000005104",
-            "display": "Education unit",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Education unit"
-              }
-            ]
+            "code": "550831000005104"
           },
           {
-            "code": "554031000005103",
-            "display": "dietician clinic",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Dietician clinic"
-              }
-            ]
+            "code": "554031000005103"
           }
         ]
       },
@@ -445,94 +158,31 @@
         "system": "http://snomed.info/sct/554471000005108/version/20180331",
         "concept": [
           {
-            "code": "557511000005107",
-            "display": "Acupuncture clinic",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Acupuncture clinic"
-              }
-            ]
+            "code": "557511000005107"
           },
           {
-            "code": "557501000005109",
-            "display": "Pharmacy branch",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Pharmacy branch"
-              }
-            ]
+            "code": "557501000005109"
           },
           {
-            "code": "557531000005103",
-            "display": "Prosthetist clinic",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Prosthetist clinic"
-              }
-            ]
+            "code": "557531000005103"
           },
           {
-            "code": "557591000005104",
-            "display": "Web-based care",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Web-based care"
-              }
-            ]
+            "code": "557591000005104"
           },
           {
-            "code": "557521000005101",
-            "display": "Alternative treatment clinic",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Alternative treatment clinic"
-              }
-            ]
+            "code": "557521000005101"
           },
           {
-            "code": "557561000005105",
-            "display": "Consulting firm",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Consulting firm"
-              }
-            ]
+            "code": "557561000005105"
           },
           {
-            "code": "557541000005106",
-            "display": "Cosmetic treatment clinic",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Cosmetic treatment clinic"
-              }
-            ]
+            "code": "557541000005106"
           },
           {
-            "code": "557581000005102",
-            "display": "Optometrist or optician clinic",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Optometrist or optician clinic"
-              }
-            ]
+            "code": "557581000005102"
           },
           {
-            "code": "556841000005105",
-            "display": "Social psychological counseling",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Social psychological counseling"
-              }
-            ]
+            "code": "556841000005105"
           }
         ]
       },
@@ -540,14 +190,7 @@
         "system": "http://snomed.info/sct/554471000005108/version/20180930",
         "concept": [
           {
-            "code": "557671000005101",
-            "display": "Osteopathy clinic",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Osteopathy clinic"
-              }
-            ]
+            "code": "557671000005101"
           }
         ]
       },
@@ -555,224 +198,70 @@
         "system": "http://snomed.info/sct",
         "concept": [
           {
-            "code": "702916001",
-            "display": "Rehabilitation clinic",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Rehabilitation clinic"
-              }
-            ]
+            "code": "702916001"
           },
           {
-            "code": "284546000",
-            "display": "Hospice",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Hospice"
-              }
-            ]
+            "code": "284546000"
           },
           {
-            "code": "272511002",
-            "display": "Municipal and civic establishment",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Municipal and civic establishment"
-              }
-            ]
+            "code": "272511002"
           },
           {
-            "code": "557891000005101",
-            "display": "Municipal health care activity unit",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Municipal health care activity unit"
-              }
-            ]
+            "code": "557891000005101"
           },
           {
-            "code": "557901000005102",
-            "display": "Preventive home care",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Preventive home care"
-              }
-            ]
+            "code": "557901000005102"
           },
           {
-            "code": "398070004",
-            "display": "State",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "State"
-              }
-            ]
+            "code": "398070004"
           },
           {
-            "code": "394761003",
-            "display": "General practitioner practice site",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "General practitioner practice site"
-              }
-            ]
+            "code": "394761003"
           },
           {
-            "code": "20078004",
-            "display": "Substance abuse treatment center",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Substance abuse treatment center"
-              }
-            ]
+            "code": "20078004"
           },
           {
-            "code": "722173008",
-            "display": "Prison based care site",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Prison based care site"
-              }
-            ]
+            "code": "722173008"
           },
           {
-            "code": "702871004",
-            "display": "Infertility clinic",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Infertility clinic"
-              }
-            ]
+            "code": "702871004"
           },
           {
-            "code": "276037005",
-            "display": "Volunteer helper",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Volunteer helper"
-              }
-            ]
+            "code": "276037005"
           },
           {
-            "code": "22232009",
-            "display": "Hospital",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Hospital"
-              }
-            ]
+            "code": "22232009"
           },
           {
-            "code": "702824005",
-            "display": "Audiology clinic",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Audiology clinic"
-              }
-            ]
+            "code": "702824005"
           },
           {
-            "code": "42665001",
-            "display": "Nursing home",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Nursing home"
-              }
-            ]
+            "code": "42665001"
           },
           {
-            "code": "264361005",
-            "display": "Health centre",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Health centre"
-              }
-            ]
+            "code": "264361005"
           },
           {
-            "code": "703069008",
-            "display": "Nurse practitioner clinic",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Nurse practitioner clinic"
-              }
-            ]
+            "code": "703069008"
           },
           {
-            "code": "309964003",
-            "display": "Radiology department",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Radiology department"
-              }
-            ]
+            "code": "309964003"
           },
           {
-            "code": "309904001",
-            "display": "Intensive care unit",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Intensive care unit"
-              }
-            ]
+            "code": "309904001"
           },
           {
-            "code": "309939001",
-            "display": "Palliative care department",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Palliative care department"
-              }
-            ]
+            "code": "309939001"
           },
           {
-            "code": "225728007",
-            "display": "Accident and Emergency department",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Accident and Emergency department"
-              }
-            ]
+            "code": "225728007"
           },
           {
-            "code": "255203001",
-            "display": "Additional values",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Additional values"
-              }
-            ]
+            "code": "255203001"
           },
           {
-            "code": "264372000",
-            "display": "Pharmacy",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Pharmacy"
-              }
-            ]
+            "code": "264372000"
           }
         ]
       }

--- a/input/resources/ValueSet-ehealth-health-conditions.json
+++ b/input/resources/ValueSet-ehealth-health-conditions.json
@@ -16,16 +16,13 @@
         "system": "urn:oid:1.2.208.176.2.4",
         "concept": [
           {
-            "code": "DJ44",
-            "display": "Kronisk obstruktiv lungesygdom"
+            "code": "DJ44"
           },
           {
-            "code": "DE10",
-            "display": "Type 1-diabetes"
+            "code": "DE10"
           },
           {
-            "code": "DI20",
-            "display": "Angina pectoris"
+            "code": "DI20"
           }
         ]
       }

--- a/input/resources/ValueSet-ehealth-observation-codes.json
+++ b/input/resources/ValueSet-ehealth-observation-codes.json
@@ -27,96 +27,28 @@
         "system": "urn:oid:1.2.208.176.2.1",
         "concept": [
           {
-            "code": "DNK05472",
-            "display": "Blodtryk systolisk;Arm",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Arm—Blodtryk(systolisk); tryk = ? mmHg"
-              }
-            ]
+            "code": "DNK05472"
           },
           {
-            "code": "DNK05473",
-            "display": "Blodtryk diastolisk;Arm",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Arm—Blodtryk(diastolisk); tryk = ? mmHg"
-              }
-            ]
+            "code": "DNK05473"
           },
           {
-            "code": "NPU03011",
-            "display": "Hb(Fe; O2-bind.; aB)—Oxygen(O2); mætn. = ?",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Oxygen saturation"
-              },
-              {
-                "language": "da",
-                "value": "Hb(Fe; O2-bind.; aB)—Oxygen(O2); mætn. = ?"
-              }
-            ]
+            "code": "NPU03011"
           },
           {
-            "code": "NPU21692",
-            "display": "Hjerte—Systole; frekv. = ? × 1/min",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Heartbeats per minute"
-              },
-              {
-                "language": "da",
-                "value": "Hjerte—Systole; frekv. = ? × 1/min"
-              }
-            ]
+            "code": "NPU21692"
           },
           {
-            "code": "NPU03804",
-            "display": "Pt—Legeme; masse = ? kg",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Weight in kilogrammes"
-              },
-              {
-                "language": "da",
-                "value": "Pt—Legeme; masse = ? kg"
-              }
-            ]
+            "code": "NPU03804"
           },
           {
-            "code": "NPU27281",
-            "display": "Pt—Legeme; massekoefficient(masse/kvadreret højde) = ? kg/m²",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Pt—Legeme; massekoefficient(masse/kvadreret højde) = ? kg/m²"
-              }
-            ]
+            "code": "NPU27281"
           },
           {
-            "code": "NPU03794",
-            "display": "Pt—Legeme; højde = ? m",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Pt—Legeme; højde = ? m"
-              }
-            ]
+            "code": "NPU03794"
           },
           {
-            "code": "NPU08676",
-            "display": "Pt—Legeme; temp. = ? °C",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Pt—Legeme; temp. = ? °C"
-              }
-            ]
+            "code": "NPU08676"
           }
         ]
       },
@@ -124,104 +56,34 @@
         "system": "urn:oid:1.2.208.184.100.8",
         "concept": [
           {
-            "code": "MCS88015",
-            "display": "FEV1;Lunge",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Lunge—Lungefunktionsundersøgelse FEV1; vol. = ? L"
-              }
-            ]
+            "code": "MCS88015"
           },
           {
-            "code": "MCS88016",
-            "display": "FVC;Lunge",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Lunge—Lungefunktionsundersøgelse vitalkapasitet FVC; vol. = ? L"
-              }
-            ]
+            "code": "MCS88016"
           },
           {
-            "code": "MCS88017",
-            "display": "FEV1/FVC;Lunge",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Lunge—FEV1/FVC; ratio = ?"
-              }
-            ]
+            "code": "MCS88017"
           },
           {
-            "code": "MCS88021",
-            "display": "MRC skala;Pt(KOL)",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Pt(KOL) —MRC skala; arb.antal(værdi 1-5) = ?"
-              }
-            ]
+            "code": "MCS88021"
           },
           {
-            "code": "MCS88023",
-            "display": "FEV1 af forventet værdi;Pt(KOL)",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Pt(KOL) - FEV1 i % af den forventede værdi (efter højde,alder og køn); ratio = ?"
-              }
-            ]
+            "code": "MCS88023"
           },
           {
-            "code": "MCS88050",
-            "display": "Rejse sætte sig testen;Pt",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Rejse sætte sig testen;Pt"
-              }
-            ]
+            "code": "MCS88050"
           },
           {
-            "code": "MCS88137",
-            "display": "CAT score;Pt",
-            "designation": [
-              {
-                "language": "da",
-                "value": "CAT score;Pt"
-              }
-            ]
+            "code": "MCS88137"
           },
           {
-            "code": "MCS88192",
-            "display": "Skridt per dag;Pt",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Skridt per dag;Pt"
-              }
-            ]
+            "code": "MCS88192"
           },
           {
-            "code": "MCS88193",
-            "display": "Skridt per uge;Pt",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Skridt per uge;Pt"
-              }
-            ]
+            "code": "MCS88193"
           },
           {
-            "code": "MCS88194",
-            "display": "Skridt;Pt",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Skridt;Pt"
-              }
-            ]
+            "code": "MCS88194"
           }
         ]
       },
@@ -229,8 +91,7 @@
         "system": "urn:oid:1.2.208.176.2.4",
         "concept": [
           {
-            "code": "ZZ3170",
-            "display": "Hjemmeblodtryksmåling udført af patienten"
+            "code": "ZZ3170"
           }
         ]
       },
@@ -238,28 +99,22 @@
         "system": "http://loinc.org",
         "concept": [
           {
-            "code": "72287-6",
-            "display": "Wound size panel"
+            "code": "72287-6"
           },
           {
-            "code": "39126-8",
-            "display": "Length of Wound"
+            "code": "39126-8"
           },
           {
-            "code": "39125-0",
-            "display": "Width of Wound"
+            "code": "39125-0"
           },
           {
-            "code": "39127-6",
-            "display": "Depth of Wound"
+            "code": "39127-6"
           },
           {
-            "code": "89260-4",
-            "display": "Area of wound"
+            "code": "89260-4"
           },
           {
-            "code": "94083-3",
-            "display": "Wound volume"
+            "code": "94083-3"
           }
         ]
       }

--- a/input/resources/ValueSet-ehealth-questionnaire-types.json
+++ b/input/resources/ValueSet-ehealth-questionnaire-types.json
@@ -30,8 +30,7 @@
         "system": "http://snomed.info/sct",
         "concept": [
           {
-            "code": "273586006",
-            "display": "Master Questionnaire (DK)"
+            "code": "273586006"
           }
         ]
       }

--- a/input/resources/ValueSet-ehealth-reference-range-type.json
+++ b/input/resources/ValueSet-ehealth-reference-range-type.json
@@ -35,12 +35,10 @@
         "system": "urn:oid:1.2.208.184.100.1",
         "concept": [
           {
-            "code": "RAL",
-            "display": "Terapeutiske grænseværdier for RØD alarm"
+            "code": "RAL"
           },
           {
-            "code": "GAL",
-            "display": "Terapeutiske grænseværdier for GUL alarm"
+            "code": "GAL"
           }
         ]
       },

--- a/input/resources/ValueSet-ehealth-relatedperson-relationshiptype.json
+++ b/input/resources/ValueSet-ehealth-relatedperson-relationshiptype.json
@@ -15,124 +15,40 @@
         "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode",
         "concept": [
           {
-            "code": "FAMMEMB",
-            "display": "family member",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Øvrig familie"
-              }
-            ]
+            "code": "FAMMEMB"
           },
           {
-            "code": "SIB",
-            "display": "sibling",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Søskende"
-              }
-            ]
+            "code": "SIB"
           },
           {
-            "code": "DOMPART",
-            "display": "domestic partner",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Registreret partner"
-              }
-            ]
+            "code": "DOMPART"
           },
           {
-            "code": "ROOM",
-            "display": "Roommate",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Samboende"
-              }
-            ]
+            "code": "ROOM"
           },
           {
-            "code": "U",
-            "display": "Unknown",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Uspecificeret pårørende"
-              }
-            ]
+            "code": "U"
           },
           {
-            "code": "NBOR",
-            "display": "neighbor",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Nabo"
-              }
-            ]
+            "code": "NBOR"
           },
           {
-            "code": "CHLDINLAW",
-            "display": "child-in-law",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Svigerbarn"
-              }
-            ]
+            "code": "CHLDINLAW"
           },
           {
-            "code": "GRNDCHILD",
-            "display": "grandchild",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Barnebarn"
-              }
-            ]
+            "code": "GRNDCHILD"
           },
           {
-            "code": "PRN",
-            "display": "parent",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Forældre"
-              }
-            ]
+            "code": "PRN"
           },
           {
-            "code": "O",
-            "display": "Other",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Ingen relationer"
-              }
-            ]
+            "code": "O"
           },
           {
-            "code": "CHILD",
-            "display": "child",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Barn"
-              }
-            ]
+            "code": "CHILD"
           },
           {
-            "code": "SPS",
-            "display": "spouse",
-            "designation": [
-              {
-                "language": "da",
-                "value": "Ægtefælle"
-              }
-            ]
+            "code": "SPS"
           }
         ]
       }

--- a/input/resources/ValueSet-ehealth-sor-organization-specialty.json
+++ b/input/resources/ValueSet-ehealth-sor-organization-specialty.json
@@ -30,34 +30,13 @@
         "system": "http://snomed.info/sct/554471000005108/version/20150731",
         "concept": [
           {
-            "code": "394812008",
-            "display": "Dental medicine specialties",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Dental medicine specialties"
-              }
-            ]
+            "code": "394812008"
           },
           {
-            "code": "551411000005104",
-            "display": "Surgical gastroenterology",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Surgical gastroenterology"
-              }
-            ]
+            "code": "551411000005104"
           },
           {
-            "code": "554011000005107",
-            "display": "Forensic medicine",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Forensic medicine"
-              }
-            ]
+            "code": "554011000005107"
           }
         ]
       },
@@ -65,486 +44,163 @@
         "system": "http://snomed.info/sct",
         "concept": [
           {
-            "code": "658171000005102",
-            "display": "hjemmepleje"
+            "code": "658171000005102"
           },
           {
-            "code": "658161000005107",
-            "display": "hjemmesygepleje"
+            "code": "658161000005107"
           },
           {
-            "code": "658151000005105",
-            "display": "sundhedsfremme og forebyggelse"
+            "code": "658151000005105"
           },
           {
-            "code": "658191000005101",
-            "display": "sundhedspleje"
+            "code": "658191000005101"
           },
           {
-            "code": "658201000005103",
-            "display": "kommunal tandpleje"
+            "code": "658201000005103"
           },
           {
-            "code": "658141000005108",
-            "display": "genoptræning efter hospitalsophold"
+            "code": "658141000005108"
           },
           {
-            "code": "658181000005104",
-            "display": "hjælpemiddelområdet"
+            "code": "658181000005104"
           },
           {
-            "code": "2903041000005106",
-            "display": "det kommunale omsorgs-, social- og sundhedsområde"
+            "code": "2903041000005106"
           },
           {
-            "code": "394537008",
-            "display": "Pediatrics",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Pediatrics"
-              }
-            ]
+            "code": "394537008"
           },
           {
-            "code": "394577000",
-            "display": "Anaesthetics",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Anaesthetics"
-              }
-            ]
+            "code": "394577000"
           },
           {
-            "code": "394579002",
-            "display": "Cardiology",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Cardiology"
-              }
-            ]
+            "code": "394579002"
           },
           {
-            "code": "394580004",
-            "display": "Clinical genetics",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Clinical genetics"
-              }
-            ]
+            "code": "394580004"
           },
           {
-            "code": "394581000",
-            "display": "Community medicine",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Community medicine"
-              }
-            ]
+            "code": "394581000"
           },
           {
-            "code": "394582007",
-            "display": "Dermatology",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Dermatology"
-              }
-            ]
+            "code": "394582007"
           },
           {
-            "code": "394583002",
-            "display": "Endocrinology",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Endocrinology"
-              }
-            ]
+            "code": "394583002"
           },
           {
-            "code": "394584008",
-            "display": "Gastroenterology",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Gastroenterology"
-              }
-            ]
+            "code": "394584008"
           },
           {
-            "code": "394585009",
-            "display": "Obstetrics and gynecology",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Obstetrics and gynecology"
-              }
-            ]
+            "code": "394585009"
           },
           {
-            "code": "394587001",
-            "display": "Psychiatry",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Psychiatry"
-              }
-            ]
+            "code": "394587001"
           },
           {
-            "code": "394588006",
-            "display": "Child and adolescent psychiatry",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Child and adolescent psychiatry"
-              }
-            ]
+            "code": "394588006"
           },
           {
-            "code": "394589003",
-            "display": "Nephrology",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Nephrology"
-              }
-            ]
+            "code": "394589003"
           },
           {
-            "code": "394591006",
-            "display": "Neurology",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Neurology"
-              }
-            ]
+            "code": "394591006"
           },
           {
-            "code": "394592004",
-            "display": "Clinical oncology",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Clinical oncology"
-              }
-            ]
+            "code": "394592004"
           },
           {
-            "code": "394594003",
-            "display": "Ophthalmology",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Ophthalmology"
-              }
-            ]
+            "code": "394594003"
           },
           {
-            "code": "394596001",
-            "display": "Chemical pathology",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Chemical pathology"
-              }
-            ]
+            "code": "394596001"
           },
           {
-            "code": "394600006",
-            "display": "Clinical pharmacology",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Clinical pharmacology"
-              }
-            ]
+            "code": "394600006"
           },
           {
-            "code": "394601005",
-            "display": "Clinical physiology",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Clinical physiology"
-              }
-            ]
+            "code": "394601005"
           },
           {
-            "code": "394603008",
-            "display": "Cardiothoracic surgery",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Cardiothoracic surgery"
-              }
-            ]
+            "code": "394603008"
           },
           {
-            "code": "394604002",
-            "display": "Ear, nose and throat surgery",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Ear, nose and throat surgery"
-              }
-            ]
+            "code": "394604002"
           },
           {
-            "code": "394605001",
-            "display": "Oral surgery",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Oral surgery"
-              }
-            ]
+            "code": "394605001"
           },
           {
-            "code": "394608004",
-            "display": "Orthodontics",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Orthodontics"
-              }
-            ]
+            "code": "394608004"
           },
           {
-            "code": "394609007",
-            "display": "General surgery",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "General surgery"
-              }
-            ]
+            "code": "394609007"
           },
           {
-            "code": "394610002",
-            "display": "Neurosurgery",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Neurosurgery"
-              }
-            ]
+            "code": "394610002"
           },
           {
-            "code": "394611003",
-            "display": "Plastic surgery - specialty",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Plastic surgery - specialty"
-              }
-            ]
+            "code": "394611003"
           },
           {
-            "code": "394612005",
-            "display": "Urology",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Urology"
-              }
-            ]
+            "code": "394612005"
           },
           {
-            "code": "394801008",
-            "display": "Trauma and orthopedics",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Trauma and orthopedics"
-              }
-            ]
+            "code": "394801008"
           },
           {
-            "code": "394803006",
-            "display": "Clinical hematology",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Clinical hematology"
-              }
-            ]
+            "code": "394803006"
           },
           {
-            "code": "394805004",
-            "display": "Clinical immunology/allergy",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Clinical immunology/allergy"
-              }
-            ]
+            "code": "394805004"
           },
           {
-            "code": "394807007",
-            "display": "Infectious diseases (specialty)",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Infectious diseases (specialty)"
-              }
-            ]
+            "code": "394807007"
           },
           {
-            "code": "394809005",
-            "display": "Clinical neuro-physiology",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Clinical neuro-physiology"
-              }
-            ]
+            "code": "394809005"
           },
           {
-            "code": "394810000",
-            "display": "Rheumatology",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Rheumatology"
-              }
-            ]
+            "code": "394810000"
           },
           {
-            "code": "394811001",
-            "display": "Geriatric medicine",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Geriatric medicine"
-              }
-            ]
+            "code": "394811001"
           },
           {
-            "code": "394821009",
-            "display": "Occupational medicine",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Occupational medicine"
-              }
-            ]
+            "code": "394821009"
           },
           {
-            "code": "394914008",
-            "display": "Radiology - speciality",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Radiology - speciality"
-              }
-            ]
+            "code": "394914008"
           },
           {
-            "code": "394915009",
-            "display": "General pathology (speciality)",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "General pathology (speciality)"
-              }
-            ]
+            "code": "394915009"
           },
           {
-            "code": "408443003",
-            "display": "General medical practice",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "General medical practice"
-              }
-            ]
+            "code": "408443003"
           },
           {
-            "code": "408448007",
-            "display": "Tropical medicine",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Tropical medicine"
-              }
-            ]
+            "code": "408448007"
           },
           {
-            "code": "408454008",
-            "display": "Clinical microbiology",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Clinical microbiology"
-              }
-            ]
+            "code": "408454008"
           },
           {
-            "code": "408463005",
-            "display": "Vascular surgery",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Vascular surgery"
-              }
-            ]
+            "code": "408463005"
           },
           {
-            "code": "408472002",
-            "display": "Hepatology",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Hepatology"
-              }
-            ]
+            "code": "408472002"
           },
           {
-            "code": "418112009",
-            "display": "Pulmonary medicine",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Pulmonary medicine"
-              }
-            ]
+            "code": "418112009"
           },
           {
-            "code": "419192003",
-            "display": "Internal medicine",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Internal medicine"
-              }
-            ]
+            "code": "419192003"
           },
           {
-            "code": "421661004",
-            "display": "Blood banking and transfusion medicine (specialty)",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Blood banking and transfusion medicine (specialty)"
-              }
-            ]
+            "code": "421661004"
           },
           {
-            "code": "773568002",
-            "display": "Emergency medicine",
-            "designation": [
-              {
-                "language": "en-US",
-                "value": "Emergency medicine"
-              }
-            ]
+            "code": "773568002"
           }
         ]
       }

--- a/input/resources/ValueSet-ehealth-sor-organization-type.json
+++ b/input/resources/ValueSet-ehealth-sor-organization-type.json
@@ -1,781 +1,270 @@
 {
-    "resourceType": "ValueSet",
-    "id": "ehealth-sor-organization-type",
-    "url": "http://ehealth.sundhed.dk/vs/sor-organization-type",
-    "version": "0.0.2",
-    "name": "SorOrganizationType",
-    "title": "SorOrganizationType",
-    "status": "active",
-    "experimental": true,
-    "date": "2019-05-27T00:00:00+00:00",
-    "publisher": "ehealth.sundhed.dk",
-    "contact": [
+  "resourceType": "ValueSet",
+  "id": "ehealth-sor-organization-type",
+  "url": "http://ehealth.sundhed.dk/vs/sor-organization-type",
+  "version": "0.0.2",
+  "name": "SorOrganizationType",
+  "title": "SorOrganizationType",
+  "status": "active",
+  "experimental": true,
+  "date": "2019-05-27T00:00:00+00:00",
+  "publisher": "ehealth.sundhed.dk",
+  "contact": [
+    {
+      "name": "ehealth.sundhed.dk",
+      "telecom": [
         {
-            "name": "ehealth.sundhed.dk",
-            "telecom": [
-                {
-                    "system": "url",
-                    "value": "http://ehealth.sundhed.dk/terminology"
-                }
-            ]
+          "system": "url",
+          "value": "http://ehealth.sundhed.dk/terminology"
         }
-    ],
-    "description": "Value set used for indicating the organization type for organizations from Sor",
-    "compose": {
-        "include": [
-            {
-                "system": "http://ehealth.sundhed.dk/cs/sor-organization-type"
-            },
-            {
-                "system": "http://snomed.info/sct/554471000005108/version/20150731",
-                "concept": [
-                    {
-                        "code": "554221000005108",
-                        "display": "Dwilling place",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Dwilling place"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "546821000005103",
-                        "display": "Occupational therapy clinic",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Occupational therapy clinic"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "547011000005103",
-                        "display": "Physiotherapy clinic",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Physiotherapy clinic"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "546811000005109",
-                        "display": "Rehabilitation center",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Rehabilitation center"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "550621000005101",
-                        "display": "District nursing",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "District nursing"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "550631000005103",
-                        "display": "Midwife clinic",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Midwife clinic"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "550641000005106",
-                        "display": "Chiropractic clinic",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Chiropractic clinic"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "550651000005108",
-                        "display": "Medical laboratory",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Medical laboratory"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "550661000005105",
-                        "display": "Emergency medical service",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Emergency medical service"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "554211000005102",
-                        "display": "Prehospital unit",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Prehospital unit"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "550711000005101",
-                        "display": "Psychological counseling clinic",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Psychological counseling clinic"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "550671000005100",
-                        "display": "Medical specialist practice site",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Medical specialist practice site"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "554061000005105",
-                        "display": "Chiropodist clinic",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Chiropodist clinic"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "554041000005106",
-                        "display": "Health administration",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Health administration"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "554021000005101",
-                        "display": "Health visitors",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Health visitors"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "550681000005102",
-                        "display": "dental practice",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Dental practice"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "550691000005104",
-                        "display": "Dental care clinic",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Dental care clinic"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "550701000005104",
-                        "display": "Dental technician clinic",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Dental technician clinic"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "554231000005106",
-                        "display": "Vaccination clinic",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Vaccination clinic"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "554051000005108",
-                        "display": "Reflexology clinic",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Reflexology clinic"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "550811000005108",
-                        "display": "Administrative unit",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Administrative unit"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "547211000005108",
-                        "display": "Municipality",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Municipality"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "550891000005100",
-                        "display": "Private",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Private"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "550881000005103",
-                        "display": "Region",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Region"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "550411000005105",
-                        "display": "Other health institution",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Other health institution"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "554851000005102",
-                        "display": "Asylum centre",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Asylum centre"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "550861000005106",
-                        "display": "Physiotherapy and occupational clinic",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Physiotherapy and occupational clinic"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "554881000005108",
-                        "display": "Handicap and psychiatry",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Handicap and psychiatry"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "554861000005100",
-                        "display": "Handicap",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Handicap"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "554821000005109",
-                        "display": "Home care",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Home care"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "554411000005101",
-                        "display": "Employment agency",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Employment agency"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "554871000005105",
-                        "display": "Psychiatry",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Psychiatry"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "550821000005102",
-                        "display": "Service unit",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Service unit"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "550871000005101",
-                        "display": "Emergency admission unit",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Emergency admission unit"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "554241000005103",
-                        "display": "Technical location number",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Technical location number"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "550841000005107",
-                        "display": "Research unit",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Research unit"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "550851000005109",
-                        "display": "Clinical unit",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Clinical unit"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "551611000005102",
-                        "display": "Surgical ward",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Surgical ward"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "554071000005100",
-                        "display": "Hospital pharmacy",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Hospital pharmacy"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "550831000005104",
-                        "display": "Education unit",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Education unit"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "554031000005103",
-                        "display": "dietician clinic",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Dietician clinic"
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
-                "system": "http://snomed.info/sct/554471000005108/version/20180331",
-                "concept": [
-                    {
-                        "code": "557511000005107",
-                        "display": "Acupuncture clinic",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Acupuncture clinic"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "557501000005109",
-                        "display": "Pharmacy branch",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Pharmacy branch"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "557531000005103",
-                        "display": "Prosthetist clinic",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Prosthetist clinic"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "557591000005104",
-                        "display": "Web-based care",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Web-based care"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "557521000005101",
-                        "display": "Alternative treatment clinic",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Alternative treatment clinic"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "557561000005105",
-                        "display": "Consulting firm",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Consulting firm"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "557541000005106",
-                        "display": "Cosmetic treatment clinic",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Cosmetic treatment clinic"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "557581000005102",
-                        "display": "Optometrist or optician clinic",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Optometrist or optician clinic"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "556841000005105",
-                        "display": "Social psychological counseling",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Social psychological counseling"
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
-                "system": "http://snomed.info/sct/554471000005108/version/20180930",
-                "concept": [
-                    {
-                        "code": "557671000005101",
-                        "display": "Osteopathy clinic",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Osteopathy clinic"
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
-                "system": "http://snomed.info/sct",
-                "concept": [
-                    {
-                        "code": "702916001",
-                        "display": "Rehabilitation clinic",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Rehabilitation clinic"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "284546000",
-                        "display": "Hospice",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Hospice"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "272511002",
-                        "display": "Municipal and civic establishment",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Municipal and civic establishment"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "557891000005101",
-                        "display": "Municipal health care activity unit",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Municipal health care activity unit"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "557901000005102",
-                        "display": "Preventive home care",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Preventive home care"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "398070004",
-                        "display": "State",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "State"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "394761003",
-                        "display": "General practitioner practice site",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "General practitioner practice site"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "20078004",
-                        "display": "Substance abuse treatment center",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Substance abuse treatment center"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "722173008",
-                        "display": "Prison based care site",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Prison based care site"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "702871004",
-                        "display": "Infertility clinic",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Infertility clinic"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "276037005",
-                        "display": "Volunteer helper",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Volunteer helper"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "22232009",
-                        "display": "Hospital",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Hospital"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "702824005",
-                        "display": "Audiology clinic",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Audiology clinic"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "42665001",
-                        "display": "Nursing home",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Nursing home"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "264361005",
-                        "display": "Health centre",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Health centre"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "703069008",
-                        "display": "Nurse practitioner clinic",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Nurse practitioner clinic"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "309964003",
-                        "display": "Radiology department",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Radiology department"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "309904001",
-                        "display": "Intensive care unit",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Intensive care unit"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "309939001",
-                        "display": "Palliative care department",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Palliative care department"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "225728007",
-                        "display": "Accident and Emergency department",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Accident and Emergency department"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "255203001",
-                        "display": "Additional values",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Additional values"
-                            }
-                        ]
-                    },
-                    {
-                        "code": "264372000",
-                        "display": "Pharmacy",
-                        "designation": [
-                            {
-                                "language": "en-US",
-                                "value": "Pharmacy"
-                            }
-                        ]
-                    }
-                ]
-            }
-        ]
+      ]
     }
+  ],
+  "description": "Value set used for indicating the organization type for organizations from Sor",
+  "compose": {
+    "include": [
+      {
+        "system": "http://ehealth.sundhed.dk/cs/sor-organization-type"
+      },
+      {
+        "system": "http://snomed.info/sct/554471000005108/version/20150731",
+        "concept": [
+          {
+            "code": "554221000005108"
+          },
+          {
+            "code": "546821000005103"
+          },
+          {
+            "code": "547011000005103"
+          },
+          {
+            "code": "546811000005109"
+          },
+          {
+            "code": "550621000005101"
+          },
+          {
+            "code": "550631000005103"
+          },
+          {
+            "code": "550641000005106"
+          },
+          {
+            "code": "550651000005108"
+          },
+          {
+            "code": "550661000005105"
+          },
+          {
+            "code": "554211000005102"
+          },
+          {
+            "code": "550711000005101"
+          },
+          {
+            "code": "550671000005100"
+          },
+          {
+            "code": "554061000005105"
+          },
+          {
+            "code": "554041000005106"
+          },
+          {
+            "code": "554021000005101"
+          },
+          {
+            "code": "550681000005102"
+          },
+          {
+            "code": "550691000005104"
+          },
+          {
+            "code": "550701000005104"
+          },
+          {
+            "code": "554231000005106"
+          },
+          {
+            "code": "554051000005108"
+          },
+          {
+            "code": "550811000005108"
+          },
+          {
+            "code": "547211000005108"
+          },
+          {
+            "code": "550891000005100"
+          },
+          {
+            "code": "550881000005103"
+          },
+          {
+            "code": "550411000005105"
+          },
+          {
+            "code": "554851000005102"
+          },
+          {
+            "code": "550861000005106"
+          },
+          {
+            "code": "554881000005108"
+          },
+          {
+            "code": "554861000005100"
+          },
+          {
+            "code": "554821000005109"
+          },
+          {
+            "code": "554411000005101"
+          },
+          {
+            "code": "554871000005105"
+          },
+          {
+            "code": "550821000005102"
+          },
+          {
+            "code": "550871000005101"
+          },
+          {
+            "code": "554241000005103"
+          },
+          {
+            "code": "550841000005107"
+          },
+          {
+            "code": "550851000005109"
+          },
+          {
+            "code": "551611000005102"
+          },
+          {
+            "code": "554071000005100"
+          },
+          {
+            "code": "550831000005104"
+          },
+          {
+            "code": "554031000005103"
+          }
+        ]
+      },
+      {
+        "system": "http://snomed.info/sct/554471000005108/version/20180331",
+        "concept": [
+          {
+            "code": "557511000005107"
+          },
+          {
+            "code": "557501000005109"
+          },
+          {
+            "code": "557531000005103"
+          },
+          {
+            "code": "557591000005104"
+          },
+          {
+            "code": "557521000005101"
+          },
+          {
+            "code": "557561000005105"
+          },
+          {
+            "code": "557541000005106"
+          },
+          {
+            "code": "557581000005102"
+          },
+          {
+            "code": "556841000005105"
+          }
+        ]
+      },
+      {
+        "system": "http://snomed.info/sct/554471000005108/version/20180930",
+        "concept": [
+          {
+            "code": "557671000005101"
+          }
+        ]
+      },
+      {
+        "system": "http://snomed.info/sct",
+        "concept": [
+          {
+            "code": "702916001"
+          },
+          {
+            "code": "284546000"
+          },
+          {
+            "code": "272511002"
+          },
+          {
+            "code": "557891000005101"
+          },
+          {
+            "code": "557901000005102"
+          },
+          {
+            "code": "398070004"
+          },
+          {
+            "code": "394761003"
+          },
+          {
+            "code": "20078004"
+          },
+          {
+            "code": "722173008"
+          },
+          {
+            "code": "702871004"
+          },
+          {
+            "code": "276037005"
+          },
+          {
+            "code": "22232009"
+          },
+          {
+            "code": "702824005"
+          },
+          {
+            "code": "42665001"
+          },
+          {
+            "code": "264361005"
+          },
+          {
+            "code": "703069008"
+          },
+          {
+            "code": "309964003"
+          },
+          {
+            "code": "309904001"
+          },
+          {
+            "code": "309939001"
+          },
+          {
+            "code": "225728007"
+          },
+          {
+            "code": "255203001"
+          },
+          {
+            "code": "264372000"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/input/resources/ValueSet-ehealth-trigger-behavior.json
+++ b/input/resources/ValueSet-ehealth-trigger-behavior.json
@@ -27,12 +27,10 @@
         "system": "http://hl7.org/fhir/action-selection-behavior",
         "concept": [
           {
-            "code": "one-or-more",
-            "display": "One Or More"
+            "code": "one-or-more"
           },
           {
-            "code": "all",
-            "display": "All"
+            "code": "all"
           }
         ]
       }

--- a/input/resources/ValueSet-sundhedsdatastyrelsen-dk-ihe-eventcodelists-vs.json
+++ b/input/resources/ValueSet-sundhedsdatastyrelsen-dk-ihe-eventcodelists-vs.json
@@ -27,36 +27,28 @@
         "system": "urn:oid:1.2.208.176.2.4",
         "concept": [
           {
-            "code": "ALAL01",
-            "display": "Kræftsygdomme"
+            "code": "ALAL01"
           },
           {
-            "code": "ALAL02",
-            "display": "Hjertesygdomme"
+            "code": "ALAL02"
           },
           {
-            "code": "ALAL03",
-            "display": "Psykiske lidelser og adfærdsmæssige forstyrrelser"
+            "code": "ALAL03"
           },
           {
-            "code": "ALAL21",
-            "display": "Kronisk obstruktiv lungesygdom (KOL)"
+            "code": "ALAL21"
           },
           {
-            "code": "ALAL22",
-            "display": "Type 2-diabetes"
+            "code": "ALAL22"
           },
           {
-            "code": "ALAL23",
-            "display": "Osteoporose"
+            "code": "ALAL23"
           },
           {
-            "code": "ALAL51",
-            "display": "Graviditet, fødsel og barsel"
+            "code": "ALAL51"
           },
           {
-            "code": "ALAL52",
-            "display": "Nyfødte"
+            "code": "ALAL52"
           }
         ]
       },
@@ -64,40 +56,31 @@
         "system": "urn:oid:1.2.208.176.2.1",
         "concept": [
           {
-            "code": "NPU03804",
-            "display": "Pt—Legeme; masse = ? kg"
+            "code": "NPU03804"
           },
           {
-            "code": "NPU03963",
-            "display": "U—Erythrocytter; arb.k.(proc.) = ?"
+            "code": "NPU03963"
           },
           {
-            "code": "NPU21692",
-            "display": "Hjerte—Systole; frekv. = ? × 1/min"
+            "code": "NPU21692"
           },
           {
-            "code": "NPU22089",
-            "display": "P(kB)—Glucose; stofk. = ? mmol/L"
+            "code": "NPU22089"
           },
           {
-            "code": "NPU03011",
-            "display": "Hb(Fe; O2-bind.; aB)—Oxygen(O2); mætn. = ?"
+            "code": "NPU03011"
           },
           {
-            "code": "NPU27281",
-            "display": "Pt—Legeme; massekoefficient(masse/kvadreret højde) = ? kg/m²"
+            "code": "NPU27281"
           },
           {
-            "code": "NPU19748",
-            "display": "P—C-reaktivt protein; massek. = ? mg/L"
+            "code": "NPU19748"
           },
           {
-            "code": "DNK05472",
-            "display": "Blodtryk systolisk;Arm"
+            "code": "DNK05472"
           },
           {
-            "code": "DNK05473",
-            "display": "Blodtryk diastolisk;Arm"
+            "code": "DNK05473"
           }
         ]
       },
@@ -105,32 +88,25 @@
         "system": "urn:oid:1.2.208.184.100.8",
         "concept": [
           {
-            "code": "MCS88100",
-            "display": "FEV6;Lunge"
+            "code": "MCS88100"
           },
           {
-            "code": "MCS88015",
-            "display": "FEV1;Lunge"
+            "code": "MCS88015"
           },
           {
-            "code": "MCS88019",
-            "display": "Blodtryk hjemme systolisk;Arm"
+            "code": "MCS88019"
           },
           {
-            "code": "MCS88020",
-            "display": "Blodtryk hjemme diastolisk;Arm"
+            "code": "MCS88020"
           },
           {
-            "code": "MCS88050",
-            "display": "Rejse sætte sig testen;Pt"
+            "code": "MCS88050"
           },
           {
-            "code": "MCS88137",
-            "display": "CAT score;Pt"
+            "code": "MCS88137"
           },
           {
-            "code": "MCS88021",
-            "display": "MRC skala;Pt(KOL)"
+            "code": "MCS88021"
           }
         ]
       },


### PR DESCRIPTION
## Summary
- Removes `display` and `designation` values from 17 ValueSet files where they were redundantly duplicated from their CodeSystems
- Display values belong in CodeSystems, not ValueSets — all referenced CodeSystems (both external like SNOMED/LOINC/NPU and internal like `ehealth-reference-range-type`) already define these values
- Resolves trifork/ehealth#1289