### PR TITLE
Update DK Core dependency from 3.5.0 to 3.6.0

### DIFF
--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -4,6 +4,7 @@ This is the log of changes made to the eHealth Implementation Guide.
 ### General changes
 - dk.core updated from 1.1.0 to 3.5.0
   - The only forced change to our implementation as a consequence of this, is that the generalPractitioner element must now contain a reference to an Organization, Practitioner or PractitionerRole. Instead of only being able to reference an Organization.
+- dk.core updated from 3.5.0 to 3.6.0
 ### Custom operations
 #### System operations
 #### Instance operations

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -23,7 +23,7 @@ publisher:
 jurisdiction: urn:iso:std:iso:3166#DK "Denmark"
 
 dependencies:
-  hl7.fhir.dk.core: 3.5.0
+  hl7.fhir.dk.core: 3.6.0
   hl7.fhir.uv.sdc: 2.7.0
 
 parameters: # see https://confluence.hl7.org/display/FHIR/Implementation+Guide+Parameters


### PR DESCRIPTION
## Summary
- Updated `hl7.fhir.dk.core` dependency from 3.5.0 to 3.6.0
- Added changelog entry for the update

IG builds successfully with the new version.