### PR TITLE
FUT1-22151 upgrade to hapi-fhir 8.6.5

### DIFF
--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -6,7 +6,10 @@ This is the log of changes made to the eHealth Implementation Guide.
   - The only forced change to our implementation as a consequence of this, is that the generalPractitioner element must now contain a reference to an Organization, Practitioner or PractitionerRole. Instead of only being able to reference an Organization.
 ### Custom operations
 #### System operations
+- Bulk export (\$export) new parameters _until and _includeHistory
+- Reindex operation (\$reindex) supports async protocol with polling status using \$hapi.fhir.reindex-status 
 #### Instance operations
+- Binary expunge (\$expunge) operation to support bulk export operations
 ### Code systems
 - Added ´fob´ (Fællesoffentlig Behandlingsplatform) to http://ehealth.sundhed.dk/cs/ehealth-program
 ### ValueSets

--- a/input/resources/CapabilityStatement-careplan.json
+++ b/input/resources/CapabilityStatement-careplan.json
@@ -3,13 +3,13 @@
   "id": "careplan",
   "name": "careplan",
   "status": "active",
-  "date": "2026-01-13T11:12:56.276+00:00",
+  "date": "2026-03-19T02:03:02.907+00:00",
   "publisher": "ehealth.sundhed.dk",
   "kind": "instance",
   "instantiates": [ "http://hl7.org/fhir/uv/bulkdata/CapabilityStatement/bulk-data" ],
   "software": {
     "name": "careplan",
-    "version": "1.37.0"
+    "version": "1.38.0"
   },
   "implementation": {
     "description": "eHealth careplan service",
@@ -28,7 +28,11 @@
         "code": "read"
       } ],
       "searchInclude": [ "*" ],
-      "searchRevInclude": [ "CarePlan:activity-reference", "CarePlan:care-team", "CarePlan:condition", "CarePlan:episodeOfCare", "CarePlan:goal", "CarePlan:instantiates-canonical", "CarePlan:part-of", "CarePlan:participant-actor", "CarePlan:patient", "Communication:episodeOfCare", "Communication:participant-actor", "Communication:recipient", "Communication:subject", "CommunicationRequest:based-on", "CommunicationRequest:encounter", "CommunicationRequest:episodeOfCare", "CommunicationRequest:patient", "CommunicationRequest:recipient", "CommunicationRequest:replaces", "CommunicationRequest:requester", "CommunicationRequest:sender", "CommunicationRequest:subject", "Consent:actor", "Consent:affiliation", "Consent:data", "Consent:patient", "DocumentReference:encounter", "DocumentReference:intendedOrganization", "DocumentReference:modifier_role_reference", "DocumentReference:subject", "EpisodeOfCare:condition", "EpisodeOfCare:organization", "EpisodeOfCare:participant-actor", "EpisodeOfCare:patient", "EpisodeOfCare:team", "Goal:addresses", "Goal:patient", "Goal:subject", "Provenance:target" ]
+      "searchRevInclude": [ "CarePlan:activity-reference", "CarePlan:care-team", "CarePlan:condition", "CarePlan:episodeOfCare", "CarePlan:goal", "CarePlan:instantiates-canonical", "CarePlan:part-of", "CarePlan:participant-actor", "CarePlan:patient", "Communication:episodeOfCare", "Communication:participant-actor", "Communication:recipient", "Communication:subject", "CommunicationRequest:based-on", "CommunicationRequest:encounter", "CommunicationRequest:episodeOfCare", "CommunicationRequest:patient", "CommunicationRequest:recipient", "CommunicationRequest:replaces", "CommunicationRequest:requester", "CommunicationRequest:sender", "CommunicationRequest:subject", "Consent:actor", "Consent:affiliation", "Consent:data", "Consent:patient", "DocumentReference:encounter", "DocumentReference:intendedOrganization", "DocumentReference:modifier_role_reference", "DocumentReference:subject", "EpisodeOfCare:condition", "EpisodeOfCare:organization", "EpisodeOfCare:participant-actor", "EpisodeOfCare:patient", "EpisodeOfCare:team", "Goal:addresses", "Goal:patient", "Goal:subject", "Provenance:target" ],
+      "operation": [ {
+        "name": "expunge",
+        "definition": "https://careplan.devtest.systematic-ehealth.com/fhir/OperationDefinition/Binary-its-expunge"
+      } ]
     }, {
       "type": "CarePlan",
       "profile": "http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-careplan",
@@ -753,6 +757,9 @@
       "name": "reindex",
       "definition": "https://careplan.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-reindex"
     }, {
+      "name": "hapi.fhir.reindex-status",
+      "definition": "https://careplan.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-hapi.fhir.reindex-status"
+    }, {
       "name": "migrate",
       "definition": "https://careplan.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-migrate",
       "documentation": "Data migration"
@@ -775,7 +782,7 @@
     }, {
       "name": "export",
       "definition": "https://careplan.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-export",
-      "documentation": "FHIR Operation to initiate an export of data from a FHIR server. The type of resources returned can be restricted using the '_type' parameter, and the '_since' parameter can be used to restrict resources to be only included if changed since the supplied time. The FHIR server support invocation of this operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/R4/async.html).\n## Initiation of export\nThe initiation of an export must specify the request header 'Prefer: respond-async', and will return '202 Accepted' with a polling location in the response header 'Content-Location'. The polling location is for the endpoint '$export-poll-status' and has the export job ID as parameter '_jobId'.\n### Parameters\n- _outputFormat: Optional parameter to specify the output format of the exported files. Default is 'application/fhir+ndjson'\n- _type: Optional parameter to specify a comma separated list of resource types to be included in the export. If not provided, all resource types will be included.\n- _since: Optional parameter to specify a time. Only resources that have been created or modified after this time will be included in the export (i.e., if Resource.meta.lastUpdated is later than the supplied _since time).\n- _typeFilter: Optional parameter to apply search filter of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied when searching resources.\n- _typePostFetchFilterUrl: Optional parameter to apply filtering of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied on resources after being fetched from the database.\n- _exportId: Optional parameter to specify a client provided identifier for the export. Resulting exported files (Binary) will be labeled with the identifer in meta extension 'https://hapifhir.org/NamingSystem/bulk-export-identifier'\n## Polling status of export\nSubsequent GET requests to the polling location will return '202 Accepted' with a response header 'X-Progress' containing a status message for the progress of the export job. When the job has finished, the polling location will return '200 OK', and the contents of the body will be a JSON object providing metadata and links to the generated bulk export data files.\n## Retrieving exported files\nThe JSON object returned when the export job is complete will contain a list of files (Binary resources) available for download. Each file can be retrieved using a standard HTTP GET request to the provided URL. The security context of the Binary resources resulting from the export is the user that initiated the export. The files can therefore only be retrieved by the same user.\n### Retention of exported files\nThe exported files are retained for a limited time after which they are deleted. The retention time is a server configuration with default 2 hours."
+      "documentation": "FHIR Operation to initiate an export of data from a FHIR server. The type of resources returned can be restricted using the '_type' parameter, and the '_since' parameter can be used to restrict resources to be only included if changed since the supplied time. The FHIR server support invocation of this operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/R4/async.html).\n## Initiation of export\nThe initiation of an export must specify the request header 'Prefer: respond-async', and will return '202 Accepted' with a polling location in the response header 'Content-Location'. The polling location is for the endpoint '$export-poll-status' and has the export job ID as parameter '_jobId'.\n### Parameters\n- _outputFormat: Optional parameter to specify the output format of the exported files. Default is 'application/fhir+ndjson'\n- _type: Optional parameter to specify a comma separated list of resource types to be included in the export. If not provided, all resource types will be included.\n- _since: Optional parameter to specify a time. Only resources that have been created or modified after this time will be included in the export (i.e., if Resource.meta.lastUpdated is later than the supplied _since time).\n- _until: Optional parameter to specify a time. Only resources that have been created or modified before this time will be included in the export (i.e., if Resource.meta.lastUpdated is earlier than the supplied _until time).\n- _typeFilter: Optional parameter to apply search filter of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied when searching resources.\n- _typePostFetchFilterUrl: Optional parameter to apply filtering of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied on resources after being fetched from the database.\n- _includeHistory: Optional parameter to specify whether historical versions of resources should be included in the export. Default is false.\n- _exportId: Optional parameter to specify a client provided identifier for the export. Resulting exported files (Binary) will be labeled with the identifer in meta extension 'https://hapifhir.org/NamingSystem/bulk-export-identifier'\n## Polling status of export\nSubsequent GET requests to the polling location will return '202 Accepted' with a response header 'X-Progress' containing a status message for the progress of the export job. When the job has finished, the polling location will return '200 OK', and the contents of the body will be a JSON object providing metadata and links to the generated bulk export data files.\n## Retrieving exported files\nThe JSON object returned when the export job is complete will contain a list of files (Binary resources) available for download. Each file can be retrieved using a standard HTTP GET request to the provided URL. The security context of the Binary resources resulting from the export is the user that initiated the export. The files can therefore only be retrieved by the same user.\n### Retention of exported files\nThe exported files are retained for a limited time after which they are deleted. The retention time is a server configuration with default 2 hours."
     }, {
       "name": "meta",
       "definition": "https://careplan.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-meta"
@@ -785,7 +792,7 @@
       "documentation": "Provides the number of resources currently stored on the server, broken down by resource type"
     }, {
       "name": "expunge",
-      "definition": "https://careplan.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-expunge"
+      "definition": "https://careplan.devtest.systematic-ehealth.com/fhir/OperationDefinition/Binary-its-expunge"
     } ]
   } ]
 }

--- a/input/resources/CapabilityStatement-device.json
+++ b/input/resources/CapabilityStatement-device.json
@@ -3,13 +3,13 @@
   "id": "device",
   "name": "device",
   "status": "active",
-  "date": "2026-01-13T11:11:33.715+00:00",
+  "date": "2026-03-19T02:07:32.260+00:00",
   "publisher": "ehealth.sundhed.dk",
   "kind": "instance",
   "instantiates": [ "http://hl7.org/fhir/uv/bulkdata/CapabilityStatement/bulk-data" ],
   "software": {
     "name": "device",
-    "version": "1.21.0"
+    "version": "1.22.0"
   },
   "implementation": {
     "description": "eHealth device service",
@@ -28,7 +28,11 @@
         "code": "read"
       } ],
       "searchInclude": [ "*" ],
-      "searchRevInclude": [ "Device:location", "Device:organization", "Device:patient", "DeviceMetric:parent", "DeviceMetric:source", "DeviceUseStatement:context", "DeviceUseStatement:device", "DeviceUseStatement:patient", "DeviceUseStatement:subject" ]
+      "searchRevInclude": [ "Device:location", "Device:organization", "Device:patient", "DeviceMetric:parent", "DeviceMetric:source", "DeviceUseStatement:context", "DeviceUseStatement:device", "DeviceUseStatement:patient", "DeviceUseStatement:subject" ],
+      "operation": [ {
+        "name": "expunge",
+        "definition": "https://device.devtest.systematic-ehealth.com/fhir/OperationDefinition/Binary-its-expunge"
+      } ]
     }, {
       "type": "Device",
       "profile": "http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-device",
@@ -314,6 +318,9 @@
       "name": "reindex",
       "definition": "https://device.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-reindex"
     }, {
+      "name": "hapi.fhir.reindex-status",
+      "definition": "https://device.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-hapi.fhir.reindex-status"
+    }, {
       "name": "migrate",
       "definition": "https://device.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-migrate",
       "documentation": "Data migration"
@@ -324,7 +331,7 @@
     }, {
       "name": "export",
       "definition": "https://device.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-export",
-      "documentation": "FHIR Operation to initiate an export of data from a FHIR server. The type of resources returned can be restricted using the '_type' parameter, and the '_since' parameter can be used to restrict resources to be only included if changed since the supplied time. The FHIR server support invocation of this operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/R4/async.html).\n## Initiation of export\nThe initiation of an export must specify the request header 'Prefer: respond-async', and will return '202 Accepted' with a polling location in the response header 'Content-Location'. The polling location is for the endpoint '$export-poll-status' and has the export job ID as parameter '_jobId'.\n### Parameters\n- _outputFormat: Optional parameter to specify the output format of the exported files. Default is 'application/fhir+ndjson'\n- _type: Optional parameter to specify a comma separated list of resource types to be included in the export. If not provided, all resource types will be included.\n- _since: Optional parameter to specify a time. Only resources that have been created or modified after this time will be included in the export (i.e., if Resource.meta.lastUpdated is later than the supplied _since time).\n- _typeFilter: Optional parameter to apply search filter of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied when searching resources.\n- _typePostFetchFilterUrl: Optional parameter to apply filtering of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied on resources after being fetched from the database.\n- _exportId: Optional parameter to specify a client provided identifier for the export. Resulting exported files (Binary) will be labeled with the identifer in meta extension 'https://hapifhir.org/NamingSystem/bulk-export-identifier'\n## Polling status of export\nSubsequent GET requests to the polling location will return '202 Accepted' with a response header 'X-Progress' containing a status message for the progress of the export job. When the job has finished, the polling location will return '200 OK', and the contents of the body will be a JSON object providing metadata and links to the generated bulk export data files.\n## Retrieving exported files\nThe JSON object returned when the export job is complete will contain a list of files (Binary resources) available for download. Each file can be retrieved using a standard HTTP GET request to the provided URL. The security context of the Binary resources resulting from the export is the user that initiated the export. The files can therefore only be retrieved by the same user.\n### Retention of exported files\nThe exported files are retained for a limited time after which they are deleted. The retention time is a server configuration with default 2 hours."
+      "documentation": "FHIR Operation to initiate an export of data from a FHIR server. The type of resources returned can be restricted using the '_type' parameter, and the '_since' parameter can be used to restrict resources to be only included if changed since the supplied time. The FHIR server support invocation of this operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/R4/async.html).\n## Initiation of export\nThe initiation of an export must specify the request header 'Prefer: respond-async', and will return '202 Accepted' with a polling location in the response header 'Content-Location'. The polling location is for the endpoint '$export-poll-status' and has the export job ID as parameter '_jobId'.\n### Parameters\n- _outputFormat: Optional parameter to specify the output format of the exported files. Default is 'application/fhir+ndjson'\n- _type: Optional parameter to specify a comma separated list of resource types to be included in the export. If not provided, all resource types will be included.\n- _since: Optional parameter to specify a time. Only resources that have been created or modified after this time will be included in the export (i.e., if Resource.meta.lastUpdated is later than the supplied _since time).\n- _until: Optional parameter to specify a time. Only resources that have been created or modified before this time will be included in the export (i.e., if Resource.meta.lastUpdated is earlier than the supplied _until time).\n- _typeFilter: Optional parameter to apply search filter of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied when searching resources.\n- _typePostFetchFilterUrl: Optional parameter to apply filtering of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied on resources after being fetched from the database.\n- _includeHistory: Optional parameter to specify whether historical versions of resources should be included in the export. Default is false.\n- _exportId: Optional parameter to specify a client provided identifier for the export. Resulting exported files (Binary) will be labeled with the identifer in meta extension 'https://hapifhir.org/NamingSystem/bulk-export-identifier'\n## Polling status of export\nSubsequent GET requests to the polling location will return '202 Accepted' with a response header 'X-Progress' containing a status message for the progress of the export job. When the job has finished, the polling location will return '200 OK', and the contents of the body will be a JSON object providing metadata and links to the generated bulk export data files.\n## Retrieving exported files\nThe JSON object returned when the export job is complete will contain a list of files (Binary resources) available for download. Each file can be retrieved using a standard HTTP GET request to the provided URL. The security context of the Binary resources resulting from the export is the user that initiated the export. The files can therefore only be retrieved by the same user.\n### Retention of exported files\nThe exported files are retained for a limited time after which they are deleted. The retention time is a server configuration with default 2 hours."
     }, {
       "name": "meta",
       "definition": "https://device.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-meta"
@@ -334,7 +341,7 @@
       "documentation": "Provides the number of resources currently stored on the server, broken down by resource type"
     }, {
       "name": "expunge",
-      "definition": "https://device.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-expunge"
+      "definition": "https://device.devtest.systematic-ehealth.com/fhir/OperationDefinition/Binary-its-expunge"
     } ]
   } ]
 }

--- a/input/resources/CapabilityStatement-document-query.json
+++ b/input/resources/CapabilityStatement-document-query.json
@@ -3,12 +3,12 @@
   "id": "document-query",
   "name": "document-query",
   "status": "active",
-  "date": "2026-01-13T11:11:48.429+00:00",
+  "date": "2026-03-19T02:12:43.398+00:00",
   "publisher": "ehealth.sundhed.dk",
   "kind": "instance",
   "software": {
     "name": "document-query",
-    "version": "1.20.0"
+    "version": "1.21.0"
   },
   "implementation": {
     "description": "eHealth document-query service",
@@ -119,6 +119,9 @@
     "operation": [ {
       "name": "reindex",
       "definition": "https://document-query.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-reindex"
+    }, {
+      "name": "hapi.fhir.reindex-status",
+      "definition": "https://document-query.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-hapi.fhir.reindex-status"
     }, {
       "name": "meta",
       "definition": "https://document-query.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-meta"

--- a/input/resources/CapabilityStatement-document-transformation.json
+++ b/input/resources/CapabilityStatement-document-transformation.json
@@ -3,13 +3,13 @@
   "id": "document-transformation",
   "name": "document-transformation",
   "status": "active",
-  "date": "2026-01-13T11:13:16.430+00:00",
+  "date": "2026-03-19T02:18:23.368+00:00",
   "publisher": "ehealth.sundhed.dk",
   "kind": "instance",
   "instantiates": [ "http://hl7.org/fhir/uv/bulkdata/CapabilityStatement/bulk-data" ],
   "software": {
     "name": "document-transformation",
-    "version": "1.31.0"
+    "version": "1.32.0"
   },
   "implementation": {
     "description": "eHealth document-transformation service",
@@ -28,7 +28,11 @@
         "code": "read"
       } ],
       "searchInclude": [ "*" ],
-      "searchRevInclude": [ "Composition:attester", "Composition:author", "Composition:encounter", "Composition:entry", "Composition:patient", "Composition:related-ref", "Composition:subject", "DocumentReference:authenticator", "DocumentReference:author", "DocumentReference:custodian", "DocumentReference:encounter", "DocumentReference:patient", "DocumentReference:related", "DocumentReference:related-ref", "DocumentReference:relatesto", "DocumentReference:subject" ]
+      "searchRevInclude": [ "Composition:attester", "Composition:author", "Composition:encounter", "Composition:entry", "Composition:patient", "Composition:related-ref", "Composition:subject", "DocumentReference:authenticator", "DocumentReference:author", "DocumentReference:custodian", "DocumentReference:encounter", "DocumentReference:patient", "DocumentReference:related", "DocumentReference:related-ref", "DocumentReference:relatesto", "DocumentReference:subject" ],
+      "operation": [ {
+        "name": "expunge",
+        "definition": "https://document-transformation.devtest.systematic-ehealth.com/fhir/OperationDefinition/Binary-its-expunge"
+      } ]
     }, {
       "type": "Composition",
       "profile": "http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-composition",
@@ -354,6 +358,9 @@
       "name": "reindex",
       "definition": "https://document-transformation.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-reindex"
     }, {
+      "name": "hapi.fhir.reindex-status",
+      "definition": "https://document-transformation.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-hapi.fhir.reindex-status"
+    }, {
       "name": "migrate",
       "definition": "https://document-transformation.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-migrate",
       "documentation": "Data migration"
@@ -404,7 +411,7 @@
     }, {
       "name": "export",
       "definition": "https://document-transformation.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-export",
-      "documentation": "FHIR Operation to initiate an export of data from a FHIR server. The type of resources returned can be restricted using the '_type' parameter, and the '_since' parameter can be used to restrict resources to be only included if changed since the supplied time. The FHIR server support invocation of this operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/R4/async.html).\n## Initiation of export\nThe initiation of an export must specify the request header 'Prefer: respond-async', and will return '202 Accepted' with a polling location in the response header 'Content-Location'. The polling location is for the endpoint '$export-poll-status' and has the export job ID as parameter '_jobId'.\n### Parameters\n- _outputFormat: Optional parameter to specify the output format of the exported files. Default is 'application/fhir+ndjson'\n- _type: Optional parameter to specify a comma separated list of resource types to be included in the export. If not provided, all resource types will be included.\n- _since: Optional parameter to specify a time. Only resources that have been created or modified after this time will be included in the export (i.e., if Resource.meta.lastUpdated is later than the supplied _since time).\n- _typeFilter: Optional parameter to apply search filter of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied when searching resources.\n- _typePostFetchFilterUrl: Optional parameter to apply filtering of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied on resources after being fetched from the database.\n- _exportId: Optional parameter to specify a client provided identifier for the export. Resulting exported files (Binary) will be labeled with the identifer in meta extension 'https://hapifhir.org/NamingSystem/bulk-export-identifier'\n## Polling status of export\nSubsequent GET requests to the polling location will return '202 Accepted' with a response header 'X-Progress' containing a status message for the progress of the export job. When the job has finished, the polling location will return '200 OK', and the contents of the body will be a JSON object providing metadata and links to the generated bulk export data files.\n## Retrieving exported files\nThe JSON object returned when the export job is complete will contain a list of files (Binary resources) available for download. Each file can be retrieved using a standard HTTP GET request to the provided URL. The security context of the Binary resources resulting from the export is the user that initiated the export. The files can therefore only be retrieved by the same user.\n### Retention of exported files\nThe exported files are retained for a limited time after which they are deleted. The retention time is a server configuration with default 2 hours."
+      "documentation": "FHIR Operation to initiate an export of data from a FHIR server. The type of resources returned can be restricted using the '_type' parameter, and the '_since' parameter can be used to restrict resources to be only included if changed since the supplied time. The FHIR server support invocation of this operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/R4/async.html).\n## Initiation of export\nThe initiation of an export must specify the request header 'Prefer: respond-async', and will return '202 Accepted' with a polling location in the response header 'Content-Location'. The polling location is for the endpoint '$export-poll-status' and has the export job ID as parameter '_jobId'.\n### Parameters\n- _outputFormat: Optional parameter to specify the output format of the exported files. Default is 'application/fhir+ndjson'\n- _type: Optional parameter to specify a comma separated list of resource types to be included in the export. If not provided, all resource types will be included.\n- _since: Optional parameter to specify a time. Only resources that have been created or modified after this time will be included in the export (i.e., if Resource.meta.lastUpdated is later than the supplied _since time).\n- _until: Optional parameter to specify a time. Only resources that have been created or modified before this time will be included in the export (i.e., if Resource.meta.lastUpdated is earlier than the supplied _until time).\n- _typeFilter: Optional parameter to apply search filter of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied when searching resources.\n- _typePostFetchFilterUrl: Optional parameter to apply filtering of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied on resources after being fetched from the database.\n- _includeHistory: Optional parameter to specify whether historical versions of resources should be included in the export. Default is false.\n- _exportId: Optional parameter to specify a client provided identifier for the export. Resulting exported files (Binary) will be labeled with the identifer in meta extension 'https://hapifhir.org/NamingSystem/bulk-export-identifier'\n## Polling status of export\nSubsequent GET requests to the polling location will return '202 Accepted' with a response header 'X-Progress' containing a status message for the progress of the export job. When the job has finished, the polling location will return '200 OK', and the contents of the body will be a JSON object providing metadata and links to the generated bulk export data files.\n## Retrieving exported files\nThe JSON object returned when the export job is complete will contain a list of files (Binary resources) available for download. Each file can be retrieved using a standard HTTP GET request to the provided URL. The security context of the Binary resources resulting from the export is the user that initiated the export. The files can therefore only be retrieved by the same user.\n### Retention of exported files\nThe exported files are retained for a limited time after which they are deleted. The retention time is a server configuration with default 2 hours."
     }, {
       "name": "meta",
       "definition": "https://document-transformation.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-meta"
@@ -414,7 +421,7 @@
       "documentation": "Provides the number of resources currently stored on the server, broken down by resource type"
     }, {
       "name": "expunge",
-      "definition": "https://document-transformation.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-expunge"
+      "definition": "https://document-transformation.devtest.systematic-ehealth.com/fhir/OperationDefinition/Binary-its-expunge"
     } ]
   } ]
 }

--- a/input/resources/CapabilityStatement-library.json
+++ b/input/resources/CapabilityStatement-library.json
@@ -3,13 +3,13 @@
   "id": "library",
   "name": "library",
   "status": "active",
-  "date": "2026-01-13T11:11:09.066+00:00",
+  "date": "2026-03-19T02:22:32.230+00:00",
   "publisher": "ehealth.sundhed.dk",
   "kind": "instance",
   "instantiates": [ "http://hl7.org/fhir/uv/bulkdata/CapabilityStatement/bulk-data" ],
   "software": {
     "name": "library",
-    "version": "1.20.0"
+    "version": "1.21.0"
   },
   "implementation": {
     "description": "eHealth library service",
@@ -28,7 +28,11 @@
         "code": "read"
       } ],
       "searchInclude": [ "*" ],
-      "searchRevInclude": [ "Library:composed-of", "Library:depends-on", "Library:derived-from", "Library:predecessor", "Library:successor" ]
+      "searchRevInclude": [ "Library:composed-of", "Library:depends-on", "Library:derived-from", "Library:predecessor", "Library:successor" ],
+      "operation": [ {
+        "name": "expunge",
+        "definition": "https://library.devtest.systematic-ehealth.com/fhir/OperationDefinition/Binary-its-expunge"
+      } ]
     }, {
       "type": "Library",
       "profile": "http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-library",
@@ -173,6 +177,9 @@
       "name": "reindex",
       "definition": "https://library.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-reindex"
     }, {
+      "name": "hapi.fhir.reindex-status",
+      "definition": "https://library.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-hapi.fhir.reindex-status"
+    }, {
       "name": "migrate",
       "definition": "https://library.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-migrate",
       "documentation": "Data migration"
@@ -183,7 +190,7 @@
     }, {
       "name": "export",
       "definition": "https://library.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-export",
-      "documentation": "FHIR Operation to initiate an export of data from a FHIR server. The type of resources returned can be restricted using the '_type' parameter, and the '_since' parameter can be used to restrict resources to be only included if changed since the supplied time. The FHIR server support invocation of this operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/R4/async.html).\n## Initiation of export\nThe initiation of an export must specify the request header 'Prefer: respond-async', and will return '202 Accepted' with a polling location in the response header 'Content-Location'. The polling location is for the endpoint '$export-poll-status' and has the export job ID as parameter '_jobId'.\n### Parameters\n- _outputFormat: Optional parameter to specify the output format of the exported files. Default is 'application/fhir+ndjson'\n- _type: Optional parameter to specify a comma separated list of resource types to be included in the export. If not provided, all resource types will be included.\n- _since: Optional parameter to specify a time. Only resources that have been created or modified after this time will be included in the export (i.e., if Resource.meta.lastUpdated is later than the supplied _since time).\n- _typeFilter: Optional parameter to apply search filter of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied when searching resources.\n- _typePostFetchFilterUrl: Optional parameter to apply filtering of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied on resources after being fetched from the database.\n- _exportId: Optional parameter to specify a client provided identifier for the export. Resulting exported files (Binary) will be labeled with the identifer in meta extension 'https://hapifhir.org/NamingSystem/bulk-export-identifier'\n## Polling status of export\nSubsequent GET requests to the polling location will return '202 Accepted' with a response header 'X-Progress' containing a status message for the progress of the export job. When the job has finished, the polling location will return '200 OK', and the contents of the body will be a JSON object providing metadata and links to the generated bulk export data files.\n## Retrieving exported files\nThe JSON object returned when the export job is complete will contain a list of files (Binary resources) available for download. Each file can be retrieved using a standard HTTP GET request to the provided URL. The security context of the Binary resources resulting from the export is the user that initiated the export. The files can therefore only be retrieved by the same user.\n### Retention of exported files\nThe exported files are retained for a limited time after which they are deleted. The retention time is a server configuration with default 2 hours."
+      "documentation": "FHIR Operation to initiate an export of data from a FHIR server. The type of resources returned can be restricted using the '_type' parameter, and the '_since' parameter can be used to restrict resources to be only included if changed since the supplied time. The FHIR server support invocation of this operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/R4/async.html).\n## Initiation of export\nThe initiation of an export must specify the request header 'Prefer: respond-async', and will return '202 Accepted' with a polling location in the response header 'Content-Location'. The polling location is for the endpoint '$export-poll-status' and has the export job ID as parameter '_jobId'.\n### Parameters\n- _outputFormat: Optional parameter to specify the output format of the exported files. Default is 'application/fhir+ndjson'\n- _type: Optional parameter to specify a comma separated list of resource types to be included in the export. If not provided, all resource types will be included.\n- _since: Optional parameter to specify a time. Only resources that have been created or modified after this time will be included in the export (i.e., if Resource.meta.lastUpdated is later than the supplied _since time).\n- _until: Optional parameter to specify a time. Only resources that have been created or modified before this time will be included in the export (i.e., if Resource.meta.lastUpdated is earlier than the supplied _until time).\n- _typeFilter: Optional parameter to apply search filter of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied when searching resources.\n- _typePostFetchFilterUrl: Optional parameter to apply filtering of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied on resources after being fetched from the database.\n- _includeHistory: Optional parameter to specify whether historical versions of resources should be included in the export. Default is false.\n- _exportId: Optional parameter to specify a client provided identifier for the export. Resulting exported files (Binary) will be labeled with the identifer in meta extension 'https://hapifhir.org/NamingSystem/bulk-export-identifier'\n## Polling status of export\nSubsequent GET requests to the polling location will return '202 Accepted' with a response header 'X-Progress' containing a status message for the progress of the export job. When the job has finished, the polling location will return '200 OK', and the contents of the body will be a JSON object providing metadata and links to the generated bulk export data files.\n## Retrieving exported files\nThe JSON object returned when the export job is complete will contain a list of files (Binary resources) available for download. Each file can be retrieved using a standard HTTP GET request to the provided URL. The security context of the Binary resources resulting from the export is the user that initiated the export. The files can therefore only be retrieved by the same user.\n### Retention of exported files\nThe exported files are retained for a limited time after which they are deleted. The retention time is a server configuration with default 2 hours."
     }, {
       "name": "meta",
       "definition": "https://library.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-meta"
@@ -193,7 +200,7 @@
       "documentation": "Provides the number of resources currently stored on the server, broken down by resource type"
     }, {
       "name": "expunge",
-      "definition": "https://library.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-expunge"
+      "definition": "https://library.devtest.systematic-ehealth.com/fhir/OperationDefinition/Binary-its-expunge"
     } ]
   } ]
 }

--- a/input/resources/CapabilityStatement-measurement.json
+++ b/input/resources/CapabilityStatement-measurement.json
@@ -3,13 +3,13 @@
   "id": "measurement",
   "name": "measurement",
   "status": "active",
-  "date": "2026-01-13T11:12:11.465+00:00",
+  "date": "2026-03-19T02:28:13.293+00:00",
   "publisher": "ehealth.sundhed.dk",
   "kind": "instance",
   "instantiates": [ "http://hl7.org/fhir/uv/bulkdata/CapabilityStatement/bulk-data" ],
   "software": {
     "name": "measurement",
-    "version": "1.29.0"
+    "version": "1.30.0"
   },
   "implementation": {
     "description": "eHealth measurement service",
@@ -28,7 +28,11 @@
         "code": "read"
       } ],
       "searchInclude": [ "*" ],
-      "searchRevInclude": [ "Communication:episodeOfCare", "Communication:recipient", "Communication:recipientCareTeam", "Communication:sender", "Communication:senderCareTeam", "Communication:subject", "Media:based-on", "Media:episodeOfCare", "Media:relatedTo", "Media:subject", "Observation:based-on", "Observation:episodeOfCare", "Observation:patient", "Observation:subject", "Provenance:agent", "Provenance:entity", "Provenance:entity-episodeOfCare", "Provenance:entity-serviceRequest", "Provenance:target", "QuestionnaireResponse:based-on", "QuestionnaireResponse:episodeOfCare", "QuestionnaireResponse:questionnaire", "QuestionnaireResponse:subject" ]
+      "searchRevInclude": [ "Communication:episodeOfCare", "Communication:recipient", "Communication:recipientCareTeam", "Communication:sender", "Communication:senderCareTeam", "Communication:subject", "Media:based-on", "Media:episodeOfCare", "Media:relatedTo", "Media:subject", "Observation:based-on", "Observation:episodeOfCare", "Observation:patient", "Observation:subject", "Provenance:agent", "Provenance:entity", "Provenance:entity-episodeOfCare", "Provenance:entity-serviceRequest", "Provenance:target", "QuestionnaireResponse:based-on", "QuestionnaireResponse:episodeOfCare", "QuestionnaireResponse:questionnaire", "QuestionnaireResponse:subject" ],
+      "operation": [ {
+        "name": "expunge",
+        "definition": "https://measurement.devtest.systematic-ehealth.com/fhir/OperationDefinition/Binary-its-expunge"
+      } ]
     }, {
       "type": "Communication",
       "profile": "http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-communication",
@@ -424,6 +428,9 @@
       "name": "reindex",
       "definition": "https://measurement.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-reindex"
     }, {
+      "name": "hapi.fhir.reindex-status",
+      "definition": "https://measurement.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-hapi.fhir.reindex-status"
+    }, {
       "name": "migrate",
       "definition": "https://measurement.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-migrate",
       "documentation": "Data migration"
@@ -446,7 +453,7 @@
     }, {
       "name": "export",
       "definition": "https://measurement.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-export",
-      "documentation": "FHIR Operation to initiate an export of data from a FHIR server. The type of resources returned can be restricted using the '_type' parameter, and the '_since' parameter can be used to restrict resources to be only included if changed since the supplied time. The FHIR server support invocation of this operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/R4/async.html).\n## Initiation of export\nThe initiation of an export must specify the request header 'Prefer: respond-async', and will return '202 Accepted' with a polling location in the response header 'Content-Location'. The polling location is for the endpoint '$export-poll-status' and has the export job ID as parameter '_jobId'.\n### Parameters\n- _outputFormat: Optional parameter to specify the output format of the exported files. Default is 'application/fhir+ndjson'\n- _type: Optional parameter to specify a comma separated list of resource types to be included in the export. If not provided, all resource types will be included.\n- _since: Optional parameter to specify a time. Only resources that have been created or modified after this time will be included in the export (i.e., if Resource.meta.lastUpdated is later than the supplied _since time).\n- _typeFilter: Optional parameter to apply search filter of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied when searching resources.\n- _typePostFetchFilterUrl: Optional parameter to apply filtering of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied on resources after being fetched from the database.\n- _exportId: Optional parameter to specify a client provided identifier for the export. Resulting exported files (Binary) will be labeled with the identifer in meta extension 'https://hapifhir.org/NamingSystem/bulk-export-identifier'\n## Polling status of export\nSubsequent GET requests to the polling location will return '202 Accepted' with a response header 'X-Progress' containing a status message for the progress of the export job. When the job has finished, the polling location will return '200 OK', and the contents of the body will be a JSON object providing metadata and links to the generated bulk export data files.\n## Retrieving exported files\nThe JSON object returned when the export job is complete will contain a list of files (Binary resources) available for download. Each file can be retrieved using a standard HTTP GET request to the provided URL. The security context of the Binary resources resulting from the export is the user that initiated the export. The files can therefore only be retrieved by the same user.\n### Retention of exported files\nThe exported files are retained for a limited time after which they are deleted. The retention time is a server configuration with default 2 hours."
+      "documentation": "FHIR Operation to initiate an export of data from a FHIR server. The type of resources returned can be restricted using the '_type' parameter, and the '_since' parameter can be used to restrict resources to be only included if changed since the supplied time. The FHIR server support invocation of this operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/R4/async.html).\n## Initiation of export\nThe initiation of an export must specify the request header 'Prefer: respond-async', and will return '202 Accepted' with a polling location in the response header 'Content-Location'. The polling location is for the endpoint '$export-poll-status' and has the export job ID as parameter '_jobId'.\n### Parameters\n- _outputFormat: Optional parameter to specify the output format of the exported files. Default is 'application/fhir+ndjson'\n- _type: Optional parameter to specify a comma separated list of resource types to be included in the export. If not provided, all resource types will be included.\n- _since: Optional parameter to specify a time. Only resources that have been created or modified after this time will be included in the export (i.e., if Resource.meta.lastUpdated is later than the supplied _since time).\n- _until: Optional parameter to specify a time. Only resources that have been created or modified before this time will be included in the export (i.e., if Resource.meta.lastUpdated is earlier than the supplied _until time).\n- _typeFilter: Optional parameter to apply search filter of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied when searching resources.\n- _typePostFetchFilterUrl: Optional parameter to apply filtering of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied on resources after being fetched from the database.\n- _includeHistory: Optional parameter to specify whether historical versions of resources should be included in the export. Default is false.\n- _exportId: Optional parameter to specify a client provided identifier for the export. Resulting exported files (Binary) will be labeled with the identifer in meta extension 'https://hapifhir.org/NamingSystem/bulk-export-identifier'\n## Polling status of export\nSubsequent GET requests to the polling location will return '202 Accepted' with a response header 'X-Progress' containing a status message for the progress of the export job. When the job has finished, the polling location will return '200 OK', and the contents of the body will be a JSON object providing metadata and links to the generated bulk export data files.\n## Retrieving exported files\nThe JSON object returned when the export job is complete will contain a list of files (Binary resources) available for download. Each file can be retrieved using a standard HTTP GET request to the provided URL. The security context of the Binary resources resulting from the export is the user that initiated the export. The files can therefore only be retrieved by the same user.\n### Retention of exported files\nThe exported files are retained for a limited time after which they are deleted. The retention time is a server configuration with default 2 hours."
     }, {
       "name": "meta",
       "definition": "https://measurement.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-meta"
@@ -456,7 +463,7 @@
       "documentation": "Provides the number of resources currently stored on the server, broken down by resource type"
     }, {
       "name": "expunge",
-      "definition": "https://measurement.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-expunge"
+      "definition": "https://measurement.devtest.systematic-ehealth.com/fhir/OperationDefinition/Binary-its-expunge"
     } ]
   } ]
 }

--- a/input/resources/CapabilityStatement-organization.json
+++ b/input/resources/CapabilityStatement-organization.json
@@ -3,13 +3,13 @@
   "id": "organization",
   "name": "organization",
   "status": "active",
-  "date": "2026-01-13T11:12:36.296+00:00",
+  "date": "2026-03-19T02:37:42.295+00:00",
   "publisher": "ehealth.sundhed.dk",
   "kind": "instance",
   "instantiates": [ "http://hl7.org/fhir/uv/bulkdata/CapabilityStatement/bulk-data" ],
   "software": {
     "name": "organization",
-    "version": "1.24.0"
+    "version": "1.25.0"
   },
   "implementation": {
     "description": "eHealth organization service",
@@ -28,7 +28,11 @@
         "code": "read"
       } ],
       "searchInclude": [ "*" ],
-      "searchRevInclude": [ "CareTeam:encounter", "CareTeam:managingOrganization", "CareTeam:participant", "CareTeam:patient", "CareTeam:subject", "Organization:endpoint", "Organization:partof", "PractitionerRole:endpoint", "PractitionerRole:location", "PractitionerRole:organization", "PractitionerRole:practitioner", "PractitionerRole:service", "Provenance:target" ]
+      "searchRevInclude": [ "CareTeam:encounter", "CareTeam:managingOrganization", "CareTeam:participant", "CareTeam:patient", "CareTeam:subject", "Organization:endpoint", "Organization:partof", "PractitionerRole:endpoint", "PractitionerRole:location", "PractitionerRole:organization", "PractitionerRole:practitioner", "PractitionerRole:service", "Provenance:target" ],
+      "operation": [ {
+        "name": "expunge",
+        "definition": "https://organization.devtest.systematic-ehealth.com/fhir/OperationDefinition/Binary-its-expunge"
+      } ]
     }, {
       "type": "CareTeam",
       "profile": "http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-careteam",
@@ -573,6 +577,9 @@
       "name": "reindex",
       "definition": "https://organization.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-reindex"
     }, {
+      "name": "hapi.fhir.reindex-status",
+      "definition": "https://organization.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-hapi.fhir.reindex-status"
+    }, {
       "name": "persist-login",
       "definition": "https://organization.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-persist-login",
       "documentation": "This operation persists login information into CareTeams and PractitionerRoles\nThe following elements of each careteam are mandatory:\n- id: Reference based on the careteam from the saml security token\n- status: any\n- name: any\n- reasonCode: any\n- participant: 1 for each careteam-role in the saml security token\n-- role: from the saml security token\n-- member: reference to the practitioner\n-- onBehalfOf: reference to organization (cannot be set currently because of a bug in hapi)\n\nPersist-login will find each careteam, and update it with any new participants and roles from the input bundle.\nThe input careteam resources are are used as a container for the participant list. The rest of the fields are not used.\nThe following elements of each PractitionerRole are mandatory:\n- practitioner\n- organization\n- code: roles from the saml security token (CareteamParticipantRole valueset)\n\nPersist-login will search for practitionerRoles for each combination of (practitioner, organization) and create it if it doesn't already exists."
@@ -587,7 +594,7 @@
     }, {
       "name": "export",
       "definition": "https://organization.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-export",
-      "documentation": "FHIR Operation to initiate an export of data from a FHIR server. The type of resources returned can be restricted using the '_type' parameter, and the '_since' parameter can be used to restrict resources to be only included if changed since the supplied time. The FHIR server support invocation of this operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/R4/async.html).\n## Initiation of export\nThe initiation of an export must specify the request header 'Prefer: respond-async', and will return '202 Accepted' with a polling location in the response header 'Content-Location'. The polling location is for the endpoint '$export-poll-status' and has the export job ID as parameter '_jobId'.\n### Parameters\n- _outputFormat: Optional parameter to specify the output format of the exported files. Default is 'application/fhir+ndjson'\n- _type: Optional parameter to specify a comma separated list of resource types to be included in the export. If not provided, all resource types will be included.\n- _since: Optional parameter to specify a time. Only resources that have been created or modified after this time will be included in the export (i.e., if Resource.meta.lastUpdated is later than the supplied _since time).\n- _typeFilter: Optional parameter to apply search filter of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied when searching resources.\n- _typePostFetchFilterUrl: Optional parameter to apply filtering of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied on resources after being fetched from the database.\n- _exportId: Optional parameter to specify a client provided identifier for the export. Resulting exported files (Binary) will be labeled with the identifer in meta extension 'https://hapifhir.org/NamingSystem/bulk-export-identifier'\n## Polling status of export\nSubsequent GET requests to the polling location will return '202 Accepted' with a response header 'X-Progress' containing a status message for the progress of the export job. When the job has finished, the polling location will return '200 OK', and the contents of the body will be a JSON object providing metadata and links to the generated bulk export data files.\n## Retrieving exported files\nThe JSON object returned when the export job is complete will contain a list of files (Binary resources) available for download. Each file can be retrieved using a standard HTTP GET request to the provided URL. The security context of the Binary resources resulting from the export is the user that initiated the export. The files can therefore only be retrieved by the same user.\n### Retention of exported files\nThe exported files are retained for a limited time after which they are deleted. The retention time is a server configuration with default 2 hours."
+      "documentation": "FHIR Operation to initiate an export of data from a FHIR server. The type of resources returned can be restricted using the '_type' parameter, and the '_since' parameter can be used to restrict resources to be only included if changed since the supplied time. The FHIR server support invocation of this operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/R4/async.html).\n## Initiation of export\nThe initiation of an export must specify the request header 'Prefer: respond-async', and will return '202 Accepted' with a polling location in the response header 'Content-Location'. The polling location is for the endpoint '$export-poll-status' and has the export job ID as parameter '_jobId'.\n### Parameters\n- _outputFormat: Optional parameter to specify the output format of the exported files. Default is 'application/fhir+ndjson'\n- _type: Optional parameter to specify a comma separated list of resource types to be included in the export. If not provided, all resource types will be included.\n- _since: Optional parameter to specify a time. Only resources that have been created or modified after this time will be included in the export (i.e., if Resource.meta.lastUpdated is later than the supplied _since time).\n- _until: Optional parameter to specify a time. Only resources that have been created or modified before this time will be included in the export (i.e., if Resource.meta.lastUpdated is earlier than the supplied _until time).\n- _typeFilter: Optional parameter to apply search filter of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied when searching resources.\n- _typePostFetchFilterUrl: Optional parameter to apply filtering of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied on resources after being fetched from the database.\n- _includeHistory: Optional parameter to specify whether historical versions of resources should be included in the export. Default is false.\n- _exportId: Optional parameter to specify a client provided identifier for the export. Resulting exported files (Binary) will be labeled with the identifer in meta extension 'https://hapifhir.org/NamingSystem/bulk-export-identifier'\n## Polling status of export\nSubsequent GET requests to the polling location will return '202 Accepted' with a response header 'X-Progress' containing a status message for the progress of the export job. When the job has finished, the polling location will return '200 OK', and the contents of the body will be a JSON object providing metadata and links to the generated bulk export data files.\n## Retrieving exported files\nThe JSON object returned when the export job is complete will contain a list of files (Binary resources) available for download. Each file can be retrieved using a standard HTTP GET request to the provided URL. The security context of the Binary resources resulting from the export is the user that initiated the export. The files can therefore only be retrieved by the same user.\n### Retention of exported files\nThe exported files are retained for a limited time after which they are deleted. The retention time is a server configuration with default 2 hours."
     }, {
       "name": "meta",
       "definition": "https://organization.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-meta"
@@ -597,7 +604,7 @@
       "documentation": "Provides the number of resources currently stored on the server, broken down by resource type"
     }, {
       "name": "expunge",
-      "definition": "https://organization.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-expunge"
+      "definition": "https://organization.devtest.systematic-ehealth.com/fhir/OperationDefinition/Binary-its-expunge"
     } ]
   } ]
 }

--- a/input/resources/CapabilityStatement-plan.json
+++ b/input/resources/CapabilityStatement-plan.json
@@ -3,13 +3,13 @@
   "id": "plan",
   "name": "plan",
   "status": "active",
-  "date": "2026-01-13T11:12:47.537+00:00",
+  "date": "2026-03-19T02:42:42.617+00:00",
   "publisher": "ehealth.sundhed.dk",
   "kind": "instance",
   "instantiates": [ "http://hl7.org/fhir/uv/bulkdata/CapabilityStatement/bulk-data" ],
   "software": {
     "name": "plan",
-    "version": "2.16.0"
+    "version": "2.17.0"
   },
   "implementation": {
     "description": "eHealth plan service",
@@ -211,7 +211,11 @@
         "code": "read"
       } ],
       "searchInclude": [ "*" ],
-      "searchRevInclude": [ "ActivityDefinition:composed-of", "ActivityDefinition:depends-on", "ActivityDefinition:derived-from", "ActivityDefinition:intendedAudience", "ActivityDefinition:modifier_role_reference", "ActivityDefinition:predecessor", "ActivityDefinition:successor", "DocumentReference:authenticator", "DocumentReference:author", "DocumentReference:custodian", "DocumentReference:encounter", "DocumentReference:intendedOrganization", "DocumentReference:modifier_role_reference", "DocumentReference:patient", "DocumentReference:related", "DocumentReference:relatesto", "DocumentReference:subject", "PlanDefinition:composed-of", "PlanDefinition:definition", "PlanDefinition:depends-on", "PlanDefinition:derived-from", "PlanDefinition:documentation", "PlanDefinition:intendedAudience", "PlanDefinition:modifier_role_reference", "PlanDefinition:predecessor", "PlanDefinition:successor" ]
+      "searchRevInclude": [ "ActivityDefinition:composed-of", "ActivityDefinition:depends-on", "ActivityDefinition:derived-from", "ActivityDefinition:intendedAudience", "ActivityDefinition:modifier_role_reference", "ActivityDefinition:predecessor", "ActivityDefinition:successor", "DocumentReference:authenticator", "DocumentReference:author", "DocumentReference:custodian", "DocumentReference:encounter", "DocumentReference:intendedOrganization", "DocumentReference:modifier_role_reference", "DocumentReference:patient", "DocumentReference:related", "DocumentReference:relatesto", "DocumentReference:subject", "PlanDefinition:composed-of", "PlanDefinition:definition", "PlanDefinition:depends-on", "PlanDefinition:derived-from", "PlanDefinition:documentation", "PlanDefinition:intendedAudience", "PlanDefinition:modifier_role_reference", "PlanDefinition:predecessor", "PlanDefinition:successor" ],
+      "operation": [ {
+        "name": "expunge",
+        "definition": "https://plan.devtest.systematic-ehealth.com/fhir/OperationDefinition/Binary-its-expunge"
+      } ]
     }, {
       "type": "DocumentReference",
       "profile": "http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-documentreference",
@@ -623,6 +627,9 @@
       "name": "reindex",
       "definition": "https://plan.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-reindex"
     }, {
+      "name": "hapi.fhir.reindex-status",
+      "definition": "https://plan.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-hapi.fhir.reindex-status"
+    }, {
       "name": "migrate",
       "definition": "https://plan.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-migrate",
       "documentation": "Data migration"
@@ -633,7 +640,7 @@
     }, {
       "name": "export",
       "definition": "https://plan.devtest.systematic-ehealth.com/fhir/OperationDefinition/PlanDefinition-is-export",
-      "documentation": "FHIR Operation to initiate an export of data from a FHIR server. The type of resources returned can be restricted using the '_type' parameter, and the '_since' parameter can be used to restrict resources to be only included if changed since the supplied time. The FHIR server support invocation of this operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/R4/async.html).\n## Initiation of export\nThe initiation of an export must specify the request header 'Prefer: respond-async', and will return '202 Accepted' with a polling location in the response header 'Content-Location'. The polling location is for the endpoint '$export-poll-status' and has the export job ID as parameter '_jobId'.\n### Parameters\n- _outputFormat: Optional parameter to specify the output format of the exported files. Default is 'application/fhir+ndjson'\n- _type: Optional parameter to specify a comma separated list of resource types to be included in the export. If not provided, all resource types will be included.\n- _since: Optional parameter to specify a time. Only resources that have been created or modified after this time will be included in the export (i.e., if Resource.meta.lastUpdated is later than the supplied _since time).\n- _typeFilter: Optional parameter to apply search filter of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied when searching resources.\n- _typePostFetchFilterUrl: Optional parameter to apply filtering of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied on resources after being fetched from the database.\n- _exportId: Optional parameter to specify a client provided identifier for the export. Resulting exported files (Binary) will be labeled with the identifer in meta extension 'https://hapifhir.org/NamingSystem/bulk-export-identifier'\n## Polling status of export\nSubsequent GET requests to the polling location will return '202 Accepted' with a response header 'X-Progress' containing a status message for the progress of the export job. When the job has finished, the polling location will return '200 OK', and the contents of the body will be a JSON object providing metadata and links to the generated bulk export data files.\n## Retrieving exported files\nThe JSON object returned when the export job is complete will contain a list of files (Binary resources) available for download. Each file can be retrieved using a standard HTTP GET request to the provided URL. The security context of the Binary resources resulting from the export is the user that initiated the export. The files can therefore only be retrieved by the same user.\n### Retention of exported files\nThe exported files are retained for a limited time after which they are deleted. The retention time is a server configuration with default 2 hours."
+      "documentation": "FHIR Operation to initiate an export of data from a FHIR server. The type of resources returned can be restricted using the '_type' parameter, and the '_since' parameter can be used to restrict resources to be only included if changed since the supplied time. The FHIR server support invocation of this operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/R4/async.html).\n## Initiation of export\nThe initiation of an export must specify the request header 'Prefer: respond-async', and will return '202 Accepted' with a polling location in the response header 'Content-Location'. The polling location is for the endpoint '$export-poll-status' and has the export job ID as parameter '_jobId'.\n### Parameters\n- _outputFormat: Optional parameter to specify the output format of the exported files. Default is 'application/fhir+ndjson'\n- _type: Optional parameter to specify a comma separated list of resource types to be included in the export. If not provided, all resource types will be included.\n- _since: Optional parameter to specify a time. Only resources that have been created or modified after this time will be included in the export (i.e., if Resource.meta.lastUpdated is later than the supplied _since time).\n- _until: Optional parameter to specify a time. Only resources that have been created or modified before this time will be included in the export (i.e., if Resource.meta.lastUpdated is earlier than the supplied _until time).\n- _typeFilter: Optional parameter to apply search filter of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied when searching resources.\n- _typePostFetchFilterUrl: Optional parameter to apply filtering of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied on resources after being fetched from the database.\n- _includeHistory: Optional parameter to specify whether historical versions of resources should be included in the export. Default is false.\n- _exportId: Optional parameter to specify a client provided identifier for the export. Resulting exported files (Binary) will be labeled with the identifer in meta extension 'https://hapifhir.org/NamingSystem/bulk-export-identifier'\n## Polling status of export\nSubsequent GET requests to the polling location will return '202 Accepted' with a response header 'X-Progress' containing a status message for the progress of the export job. When the job has finished, the polling location will return '200 OK', and the contents of the body will be a JSON object providing metadata and links to the generated bulk export data files.\n## Retrieving exported files\nThe JSON object returned when the export job is complete will contain a list of files (Binary resources) available for download. Each file can be retrieved using a standard HTTP GET request to the provided URL. The security context of the Binary resources resulting from the export is the user that initiated the export. The files can therefore only be retrieved by the same user.\n### Retention of exported files\nThe exported files are retained for a limited time after which they are deleted. The retention time is a server configuration with default 2 hours."
     }, {
       "name": "meta",
       "definition": "https://plan.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-meta"
@@ -643,7 +650,7 @@
       "documentation": "Provides the number of resources currently stored on the server, broken down by resource type"
     }, {
       "name": "expunge",
-      "definition": "https://plan.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-expunge"
+      "definition": "https://plan.devtest.systematic-ehealth.com/fhir/OperationDefinition/Binary-its-expunge"
     } ]
   } ]
 }

--- a/input/resources/CapabilityStatement-questionnaire.json
+++ b/input/resources/CapabilityStatement-questionnaire.json
@@ -3,13 +3,13 @@
   "id": "questionnaire",
   "name": "questionnaire",
   "status": "active",
-  "date": "2026-01-13T11:11:24.818+00:00",
+  "date": "2026-03-19T02:47:32.430+00:00",
   "publisher": "ehealth.sundhed.dk",
   "kind": "instance",
   "instantiates": [ "http://hl7.org/fhir/uv/bulkdata/CapabilityStatement/bulk-data" ],
   "software": {
     "name": "questionnaire",
-    "version": "2.16.0"
+    "version": "2.17.0"
   },
   "implementation": {
     "description": "eHealth questionnaire service",
@@ -151,7 +151,11 @@
         "code": "read"
       } ],
       "searchInclude": [ "*" ],
-      "searchRevInclude": [ "Basic:actionGuidanceForReference", "Basic:intendedAudience", "Basic:reference", "Basic:viewForReference", "Questionnaire:reference", "StructureDefinition:valueset" ]
+      "searchRevInclude": [ "Basic:actionGuidanceForReference", "Basic:intendedAudience", "Basic:reference", "Basic:viewForReference", "Questionnaire:reference", "StructureDefinition:valueset" ],
+      "operation": [ {
+        "name": "expunge",
+        "definition": "https://questionnaire.devtest.systematic-ehealth.com/fhir/OperationDefinition/Binary-its-expunge"
+      } ]
     }, {
       "type": "OperationDefinition",
       "profile": "http://hl7.org/fhir/StructureDefinition/OperationDefinition",
@@ -476,6 +480,9 @@
       "name": "reindex",
       "definition": "https://questionnaire.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-reindex"
     }, {
+      "name": "hapi.fhir.reindex-status",
+      "definition": "https://questionnaire.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-hapi.fhir.reindex-status"
+    }, {
       "name": "migrate",
       "definition": "https://questionnaire.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-migrate",
       "documentation": "Data migration"
@@ -486,7 +493,7 @@
     }, {
       "name": "export",
       "definition": "https://questionnaire.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-export",
-      "documentation": "FHIR Operation to initiate an export of data from a FHIR server. The type of resources returned can be restricted using the '_type' parameter, and the '_since' parameter can be used to restrict resources to be only included if changed since the supplied time. The FHIR server support invocation of this operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/R4/async.html).\n## Initiation of export\nThe initiation of an export must specify the request header 'Prefer: respond-async', and will return '202 Accepted' with a polling location in the response header 'Content-Location'. The polling location is for the endpoint '$export-poll-status' and has the export job ID as parameter '_jobId'.\n### Parameters\n- _outputFormat: Optional parameter to specify the output format of the exported files. Default is 'application/fhir+ndjson'\n- _type: Optional parameter to specify a comma separated list of resource types to be included in the export. If not provided, all resource types will be included.\n- _since: Optional parameter to specify a time. Only resources that have been created or modified after this time will be included in the export (i.e., if Resource.meta.lastUpdated is later than the supplied _since time).\n- _typeFilter: Optional parameter to apply search filter of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied when searching resources.\n- _typePostFetchFilterUrl: Optional parameter to apply filtering of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied on resources after being fetched from the database.\n- _exportId: Optional parameter to specify a client provided identifier for the export. Resulting exported files (Binary) will be labeled with the identifer in meta extension 'https://hapifhir.org/NamingSystem/bulk-export-identifier'\n## Polling status of export\nSubsequent GET requests to the polling location will return '202 Accepted' with a response header 'X-Progress' containing a status message for the progress of the export job. When the job has finished, the polling location will return '200 OK', and the contents of the body will be a JSON object providing metadata and links to the generated bulk export data files.\n## Retrieving exported files\nThe JSON object returned when the export job is complete will contain a list of files (Binary resources) available for download. Each file can be retrieved using a standard HTTP GET request to the provided URL. The security context of the Binary resources resulting from the export is the user that initiated the export. The files can therefore only be retrieved by the same user.\n### Retention of exported files\nThe exported files are retained for a limited time after which they are deleted. The retention time is a server configuration with default 2 hours."
+      "documentation": "FHIR Operation to initiate an export of data from a FHIR server. The type of resources returned can be restricted using the '_type' parameter, and the '_since' parameter can be used to restrict resources to be only included if changed since the supplied time. The FHIR server support invocation of this operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/R4/async.html).\n## Initiation of export\nThe initiation of an export must specify the request header 'Prefer: respond-async', and will return '202 Accepted' with a polling location in the response header 'Content-Location'. The polling location is for the endpoint '$export-poll-status' and has the export job ID as parameter '_jobId'.\n### Parameters\n- _outputFormat: Optional parameter to specify the output format of the exported files. Default is 'application/fhir+ndjson'\n- _type: Optional parameter to specify a comma separated list of resource types to be included in the export. If not provided, all resource types will be included.\n- _since: Optional parameter to specify a time. Only resources that have been created or modified after this time will be included in the export (i.e., if Resource.meta.lastUpdated is later than the supplied _since time).\n- _until: Optional parameter to specify a time. Only resources that have been created or modified before this time will be included in the export (i.e., if Resource.meta.lastUpdated is earlier than the supplied _until time).\n- _typeFilter: Optional parameter to apply search filter of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied when searching resources.\n- _typePostFetchFilterUrl: Optional parameter to apply filtering of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied on resources after being fetched from the database.\n- _includeHistory: Optional parameter to specify whether historical versions of resources should be included in the export. Default is false.\n- _exportId: Optional parameter to specify a client provided identifier for the export. Resulting exported files (Binary) will be labeled with the identifer in meta extension 'https://hapifhir.org/NamingSystem/bulk-export-identifier'\n## Polling status of export\nSubsequent GET requests to the polling location will return '202 Accepted' with a response header 'X-Progress' containing a status message for the progress of the export job. When the job has finished, the polling location will return '200 OK', and the contents of the body will be a JSON object providing metadata and links to the generated bulk export data files.\n## Retrieving exported files\nThe JSON object returned when the export job is complete will contain a list of files (Binary resources) available for download. Each file can be retrieved using a standard HTTP GET request to the provided URL. The security context of the Binary resources resulting from the export is the user that initiated the export. The files can therefore only be retrieved by the same user.\n### Retention of exported files\nThe exported files are retained for a limited time after which they are deleted. The retention time is a server configuration with default 2 hours."
     }, {
       "name": "meta",
       "definition": "https://questionnaire.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-meta"
@@ -496,7 +503,7 @@
       "documentation": "Provides the number of resources currently stored on the server, broken down by resource type"
     }, {
       "name": "expunge",
-      "definition": "https://questionnaire.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-expunge"
+      "definition": "https://questionnaire.devtest.systematic-ehealth.com/fhir/OperationDefinition/Binary-its-expunge"
     } ]
   } ]
 }

--- a/input/resources/CapabilityStatement-reporting.json
+++ b/input/resources/CapabilityStatement-reporting.json
@@ -3,12 +3,12 @@
   "id": "reporting",
   "name": "reporting",
   "status": "active",
-  "date": "2026-01-13T11:12:00.772+00:00",
+  "date": "2026-03-19T02:52:23.163+00:00",
   "publisher": "ehealth.sundhed.dk",
   "kind": "instance",
   "software": {
     "name": "reporting",
-    "version": "1.23.0"
+    "version": "1.24.0"
   },
   "implementation": {
     "description": "eHealth reporting service",
@@ -41,6 +41,9 @@
     "operation": [ {
       "name": "reindex",
       "definition": "https://reporting.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-reindex"
+    }, {
+      "name": "hapi.fhir.reindex-status",
+      "definition": "https://reporting.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-hapi.fhir.reindex-status"
     }, {
       "name": "get-report-job-status",
       "definition": "https://reporting.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-get-report-job-status",

--- a/input/resources/CapabilityStatement-task.json
+++ b/input/resources/CapabilityStatement-task.json
@@ -3,13 +3,13 @@
   "id": "task",
   "name": "task",
   "status": "active",
-  "date": "2026-01-13T11:12:19.227+00:00",
+  "date": "2026-03-18T09:57:31.195+00:00",
   "publisher": "ehealth.sundhed.dk",
   "kind": "instance",
   "instantiates": [ "http://hl7.org/fhir/uv/bulkdata/CapabilityStatement/bulk-data" ],
   "software": {
     "name": "task",
-    "version": "1.28.0"
+    "version": "1.30.0"
   },
   "implementation": {
     "description": "eHealth task service",
@@ -28,7 +28,11 @@
         "code": "read"
       } ],
       "searchInclude": [ "*" ],
-      "searchRevInclude": [ "ClinicalImpression:action", "ClinicalImpression:assessor", "ClinicalImpression:carePlan", "ClinicalImpression:episodeOfCare", "ClinicalImpression:finding-ref", "ClinicalImpression:investigation", "ClinicalImpression:patient", "ClinicalImpression:previous", "ClinicalImpression:problem", "ClinicalImpression:subject", "Task:based-on", "Task:carePlan", "Task:episodeOfCare", "Task:focus", "Task:owner", "Task:part-of", "Task:patient", "Task:requester", "Task:responsible", "Task:subject" ]
+      "searchRevInclude": [ "ClinicalImpression:action", "ClinicalImpression:assessor", "ClinicalImpression:carePlan", "ClinicalImpression:episodeOfCare", "ClinicalImpression:finding-ref", "ClinicalImpression:investigation", "ClinicalImpression:patient", "ClinicalImpression:previous", "ClinicalImpression:problem", "ClinicalImpression:subject", "Task:based-on", "Task:carePlan", "Task:episodeOfCare", "Task:focus", "Task:owner", "Task:part-of", "Task:patient", "Task:requester", "Task:responsible", "Task:subject" ],
+      "operation": [ {
+        "name": "expunge",
+        "definition": "https://task.devtest.systematic-ehealth.com/fhir/OperationDefinition/Binary-its-expunge"
+      } ]
     }, {
       "type": "ClinicalImpression",
       "profile": "http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-clinicalimpression",
@@ -330,6 +334,9 @@
       "name": "reindex",
       "definition": "https://task.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-reindex"
     }, {
+      "name": "hapi.fhir.reindex-status",
+      "definition": "https://task.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-hapi.fhir.reindex-status"
+    }, {
       "name": "migrate",
       "definition": "https://task.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-migrate",
       "documentation": "Data migration"
@@ -340,7 +347,7 @@
     }, {
       "name": "export",
       "definition": "https://task.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-export",
-      "documentation": "FHIR Operation to initiate an export of data from a FHIR server. The type of resources returned can be restricted using the '_type' parameter, and the '_since' parameter can be used to restrict resources to be only included if changed since the supplied time. The FHIR server support invocation of this operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/R4/async.html).\n## Initiation of export\nThe initiation of an export must specify the request header 'Prefer: respond-async', and will return '202 Accepted' with a polling location in the response header 'Content-Location'. The polling location is for the endpoint '$export-poll-status' and has the export job ID as parameter '_jobId'.\n### Parameters\n- _outputFormat: Optional parameter to specify the output format of the exported files. Default is 'application/fhir+ndjson'\n- _type: Optional parameter to specify a comma separated list of resource types to be included in the export. If not provided, all resource types will be included.\n- _since: Optional parameter to specify a time. Only resources that have been created or modified after this time will be included in the export (i.e., if Resource.meta.lastUpdated is later than the supplied _since time).\n- _typeFilter: Optional parameter to apply search filter of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied when searching resources.\n- _typePostFetchFilterUrl: Optional parameter to apply filtering of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied on resources after being fetched from the database.\n- _exportId: Optional parameter to specify a client provided identifier for the export. Resulting exported files (Binary) will be labeled with the identifer in meta extension 'https://hapifhir.org/NamingSystem/bulk-export-identifier'\n## Polling status of export\nSubsequent GET requests to the polling location will return '202 Accepted' with a response header 'X-Progress' containing a status message for the progress of the export job. When the job has finished, the polling location will return '200 OK', and the contents of the body will be a JSON object providing metadata and links to the generated bulk export data files.\n## Retrieving exported files\nThe JSON object returned when the export job is complete will contain a list of files (Binary resources) available for download. Each file can be retrieved using a standard HTTP GET request to the provided URL. The security context of the Binary resources resulting from the export is the user that initiated the export. The files can therefore only be retrieved by the same user.\n### Retention of exported files\nThe exported files are retained for a limited time after which they are deleted. The retention time is a server configuration with default 2 hours."
+      "documentation": "FHIR Operation to initiate an export of data from a FHIR server. The type of resources returned can be restricted using the '_type' parameter, and the '_since' parameter can be used to restrict resources to be only included if changed since the supplied time. The FHIR server support invocation of this operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/R4/async.html).\n## Initiation of export\nThe initiation of an export must specify the request header 'Prefer: respond-async', and will return '202 Accepted' with a polling location in the response header 'Content-Location'. The polling location is for the endpoint '$export-poll-status' and has the export job ID as parameter '_jobId'.\n### Parameters\n- _outputFormat: Optional parameter to specify the output format of the exported files. Default is 'application/fhir+ndjson'\n- _type: Optional parameter to specify a comma separated list of resource types to be included in the export. If not provided, all resource types will be included.\n- _since: Optional parameter to specify a time. Only resources that have been created or modified after this time will be included in the export (i.e., if Resource.meta.lastUpdated is later than the supplied _since time).\n- _until: Optional parameter to specify a time. Only resources that have been created or modified before this time will be included in the export (i.e., if Resource.meta.lastUpdated is earlier than the supplied _until time).\n- _typeFilter: Optional parameter to apply search filter of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied when searching resources.\n- _typePostFetchFilterUrl: Optional parameter to apply filtering of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied on resources after being fetched from the database.\n- _includeHistory: Optional parameter to specify whether historical versions of resources should be included in the export. Default is false.\n- _exportId: Optional parameter to specify a client provided identifier for the export. Resulting exported files (Binary) will be labeled with the identifer in meta extension 'https://hapifhir.org/NamingSystem/bulk-export-identifier'\n## Polling status of export\nSubsequent GET requests to the polling location will return '202 Accepted' with a response header 'X-Progress' containing a status message for the progress of the export job. When the job has finished, the polling location will return '200 OK', and the contents of the body will be a JSON object providing metadata and links to the generated bulk export data files.\n## Retrieving exported files\nThe JSON object returned when the export job is complete will contain a list of files (Binary resources) available for download. Each file can be retrieved using a standard HTTP GET request to the provided URL. The security context of the Binary resources resulting from the export is the user that initiated the export. The files can therefore only be retrieved by the same user.\n### Retention of exported files\nThe exported files are retained for a limited time after which they are deleted. The retention time is a server configuration with default 2 hours."
     }, {
       "name": "meta",
       "definition": "https://task.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-meta"
@@ -350,7 +357,7 @@
       "documentation": "Provides the number of resources currently stored on the server, broken down by resource type"
     }, {
       "name": "expunge",
-      "definition": "https://task.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-expunge"
+      "definition": "https://task.devtest.systematic-ehealth.com/fhir/OperationDefinition/Binary-its-expunge"
     } ]
   } ]
 }

--- a/input/resources/CapabilityStatement-terminology.json
+++ b/input/resources/CapabilityStatement-terminology.json
@@ -3,13 +3,13 @@
   "id": "terminology",
   "name": "terminology",
   "status": "active",
-  "date": "2026-01-13T11:23:33.524+00:00",
+  "date": "2026-03-18T18:27:03.325+00:00",
   "publisher": "ehealth.sundhed.dk",
   "kind": "instance",
   "instantiates": [ "http://hl7.org/fhir/uv/bulkdata/CapabilityStatement/bulk-data" ],
   "software": {
     "name": "terminology",
-    "version": "1.23.0"
+    "version": "1.24.0"
   },
   "implementation": {
     "description": "eHealth terminology service",
@@ -28,7 +28,11 @@
         "code": "read"
       } ],
       "searchInclude": [ "*" ],
-      "searchRevInclude": [ "CodeSystem:supplements", "ConceptMap:other", "ConceptMap:source", "ConceptMap:source-uri", "ConceptMap:target", "ConceptMap:target-uri", "Group:managing-entity", "Group:member" ]
+      "searchRevInclude": [ "CodeSystem:supplements", "ConceptMap:other", "ConceptMap:source", "ConceptMap:source-uri", "ConceptMap:target", "ConceptMap:target-uri", "Group:managing-entity", "Group:member" ],
+      "operation": [ {
+        "name": "expunge",
+        "definition": "https://terminology.devtest.systematic-ehealth.com/fhir/OperationDefinition/Multi-its-expunge"
+      } ]
     }, {
       "type": "CodeSystem",
       "profile": "http://hl7.org/fhir/StructureDefinition/CodeSystem",
@@ -87,11 +91,11 @@
       }, {
         "name": "_profile",
         "type": "uri",
-        "documentation": "Search for resources which have the given profile"
+        "documentation": "The profile of the resource"
       }, {
         "name": "_security",
         "type": "token",
-        "documentation": "Search for resources which have the given security labels"
+        "documentation": "The security of the resource"
       }, {
         "name": "_source",
         "type": "uri",
@@ -99,7 +103,7 @@
       }, {
         "name": "_tag",
         "type": "token",
-        "documentation": "Search for resources which have the given tag"
+        "documentation": "The tag of the resource"
       }, {
         "name": "_text",
         "type": "string",
@@ -280,11 +284,11 @@
       }, {
         "name": "_profile",
         "type": "uri",
-        "documentation": "Search for resources which have the given profile"
+        "documentation": "The profile of the resource"
       }, {
         "name": "_security",
         "type": "token",
-        "documentation": "Search for resources which have the given security labels"
+        "documentation": "The security of the resource"
       }, {
         "name": "_source",
         "type": "uri",
@@ -292,7 +296,7 @@
       }, {
         "name": "_tag",
         "type": "token",
-        "documentation": "Search for resources which have the given tag"
+        "documentation": "The tag of the resource"
       }, {
         "name": "_text",
         "type": "string",
@@ -482,11 +486,11 @@
       }, {
         "name": "_profile",
         "type": "uri",
-        "documentation": "Search for resources which have the given profile"
+        "documentation": "The profile of the resource"
       }, {
         "name": "_security",
         "type": "token",
-        "documentation": "Search for resources which have the given security labels"
+        "documentation": "The security of the resource"
       }, {
         "name": "_source",
         "type": "uri",
@@ -494,7 +498,7 @@
       }, {
         "name": "_tag",
         "type": "token",
-        "documentation": "Search for resources which have the given tag"
+        "documentation": "The tag of the resource"
       }, {
         "name": "_text",
         "type": "string",
@@ -617,11 +621,11 @@
       }, {
         "name": "_profile",
         "type": "uri",
-        "documentation": "Search for resources which have the given profile"
+        "documentation": "The profile of the resource"
       }, {
         "name": "_security",
         "type": "token",
-        "documentation": "Search for resources which have the given security labels"
+        "documentation": "The security of the resource"
       }, {
         "name": "_source",
         "type": "uri",
@@ -629,7 +633,7 @@
       }, {
         "name": "_tag",
         "type": "token",
-        "documentation": "Search for resources which have the given tag"
+        "documentation": "The tag of the resource"
       }, {
         "name": "_text",
         "type": "string",
@@ -796,11 +800,11 @@
       }, {
         "name": "_profile",
         "type": "uri",
-        "documentation": "Search for resources which have the given profile"
+        "documentation": "The profile of the resource"
       }, {
         "name": "_security",
         "type": "token",
-        "documentation": "Search for resources which have the given security labels"
+        "documentation": "The security of the resource"
       }, {
         "name": "_source",
         "type": "uri",
@@ -808,7 +812,7 @@
       }, {
         "name": "_tag",
         "type": "token",
-        "documentation": "Search for resources which have the given tag"
+        "documentation": "The tag of the resource"
       }, {
         "name": "_text",
         "type": "string",
@@ -974,11 +978,11 @@
       }, {
         "name": "_profile",
         "type": "uri",
-        "documentation": "Search for resources which have the given profile"
+        "documentation": "The profile of the resource"
       }, {
         "name": "_security",
         "type": "token",
-        "documentation": "Search for resources which have the given security labels"
+        "documentation": "The security of the resource"
       }, {
         "name": "_source",
         "type": "uri",
@@ -986,7 +990,7 @@
       }, {
         "name": "_tag",
         "type": "token",
-        "documentation": "Search for resources which have the given tag"
+        "documentation": "The tag of the resource"
       }, {
         "name": "_text",
         "type": "string",
@@ -1097,6 +1101,9 @@
       "name": "reindex",
       "definition": "https://terminology.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-reindex"
     }, {
+      "name": "hapi.fhir.reindex-status",
+      "definition": "https://terminology.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-hapi.fhir.reindex-status"
+    }, {
       "name": "import",
       "definition": "https://terminology.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-import",
       "documentation": "Import terminology resources"
@@ -1107,7 +1114,7 @@
     }, {
       "name": "export",
       "definition": "https://terminology.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-export",
-      "documentation": "FHIR Operation to initiate an export of data from a FHIR server. The type of resources returned can be restricted using the '_type' parameter, and the '_since' parameter can be used to restrict resources to be only included if changed since the supplied time. The FHIR server support invocation of this operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/R4/async.html).\n## Initiation of export\nThe initiation of an export must specify the request header 'Prefer: respond-async', and will return '202 Accepted' with a polling location in the response header 'Content-Location'. The polling location is for the endpoint '$export-poll-status' and has the export job ID as parameter '_jobId'.\n### Parameters\n- _outputFormat: Optional parameter to specify the output format of the exported files. Default is 'application/fhir+ndjson'\n- _type: Optional parameter to specify a comma separated list of resource types to be included in the export. If not provided, all resource types will be included.\n- _since: Optional parameter to specify a time. Only resources that have been created or modified after this time will be included in the export (i.e., if Resource.meta.lastUpdated is later than the supplied _since time).\n- _typeFilter: Optional parameter to apply search filter of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied when searching resources.\n- _typePostFetchFilterUrl: Optional parameter to apply filtering of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied on resources after being fetched from the database.\n- _exportId: Optional parameter to specify a client provided identifier for the export. Resulting exported files (Binary) will be labeled with the identifer in meta extension 'https://hapifhir.org/NamingSystem/bulk-export-identifier'\n## Polling status of export\nSubsequent GET requests to the polling location will return '202 Accepted' with a response header 'X-Progress' containing a status message for the progress of the export job. When the job has finished, the polling location will return '200 OK', and the contents of the body will be a JSON object providing metadata and links to the generated bulk export data files.\n## Retrieving exported files\nThe JSON object returned when the export job is complete will contain a list of files (Binary resources) available for download. Each file can be retrieved using a standard HTTP GET request to the provided URL. The security context of the Binary resources resulting from the export is the user that initiated the export. The files can therefore only be retrieved by the same user.\n### Retention of exported files\nThe exported files are retained for a limited time after which they are deleted. The retention time is a server configuration with default 2 hours."
+      "documentation": "FHIR Operation to initiate an export of data from a FHIR server. The type of resources returned can be restricted using the '_type' parameter, and the '_since' parameter can be used to restrict resources to be only included if changed since the supplied time. The FHIR server support invocation of this operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/R4/async.html).\n## Initiation of export\nThe initiation of an export must specify the request header 'Prefer: respond-async', and will return '202 Accepted' with a polling location in the response header 'Content-Location'. The polling location is for the endpoint '$export-poll-status' and has the export job ID as parameter '_jobId'.\n### Parameters\n- _outputFormat: Optional parameter to specify the output format of the exported files. Default is 'application/fhir+ndjson'\n- _type: Optional parameter to specify a comma separated list of resource types to be included in the export. If not provided, all resource types will be included.\n- _since: Optional parameter to specify a time. Only resources that have been created or modified after this time will be included in the export (i.e., if Resource.meta.lastUpdated is later than the supplied _since time).\n- _until: Optional parameter to specify a time. Only resources that have been created or modified before this time will be included in the export (i.e., if Resource.meta.lastUpdated is earlier than the supplied _until time).\n- _typeFilter: Optional parameter to apply search filter of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied when searching resources.\n- _typePostFetchFilterUrl: Optional parameter to apply filtering of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied on resources after being fetched from the database.\n- _includeHistory: Optional parameter to specify whether historical versions of resources should be included in the export. Default is false.\n- _exportId: Optional parameter to specify a client provided identifier for the export. Resulting exported files (Binary) will be labeled with the identifer in meta extension 'https://hapifhir.org/NamingSystem/bulk-export-identifier'\n## Polling status of export\nSubsequent GET requests to the polling location will return '202 Accepted' with a response header 'X-Progress' containing a status message for the progress of the export job. When the job has finished, the polling location will return '200 OK', and the contents of the body will be a JSON object providing metadata and links to the generated bulk export data files.\n## Retrieving exported files\nThe JSON object returned when the export job is complete will contain a list of files (Binary resources) available for download. Each file can be retrieved using a standard HTTP GET request to the provided URL. The security context of the Binary resources resulting from the export is the user that initiated the export. The files can therefore only be retrieved by the same user.\n### Retention of exported files\nThe exported files are retained for a limited time after which they are deleted. The retention time is a server configuration with default 2 hours."
     }, {
       "name": "reindex-terminology",
       "definition": "https://terminology.devtest.systematic-ehealth.com/fhir/OperationDefinition/-s-reindex-terminology"

--- a/input/resources/OperationDefinition--s-export.json
+++ b/input/resources/OperationDefinition--s-export.json
@@ -6,7 +6,7 @@
   "title": "FHIR Bulk Data System Level Export",
   "status": "active",
   "kind": "operation",
-  "description": "FHIR Operation to initiate an export of data from a FHIR server. The type of resources returned can be restricted using the '_type' parameter, and the '_since' parameter can be used to restrict resources to be only included if changed since the supplied time. The FHIR server support invocation of this operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/R4/async.html).\n## Initiation of export\nThe initiation of an export must specify the request header 'Prefer: respond-async', and will return '202 Accepted' with a polling location in the response header 'Content-Location'. The polling location is for the endpoint '$export-poll-status' and has the export job ID as parameter '_jobId'.\n### Parameters\n- _outputFormat: Optional parameter to specify the output format of the exported files. Default is 'application/fhir+ndjson'\n- _type: Optional parameter to specify a comma separated list of resource types to be included in the export. If not provided, all resource types will be included.\n- _since: Optional parameter to specify a time. Only resources that have been created or modified after this time will be included in the export (i.e., if Resource.meta.lastUpdated is later than the supplied _since time).\n- _typeFilter: Optional parameter to apply search filter of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied when searching resources.\n- _typePostFetchFilterUrl: Optional parameter to apply filtering of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied on resources after being fetched from the database.\n- _exportId: Optional parameter to specify a client provided identifier for the export. Resulting exported files (Binary) will be labeled with the identifer in meta extension 'https://hapifhir.org/NamingSystem/bulk-export-identifier'\n## Polling status of export\nSubsequent GET requests to the polling location will return '202 Accepted' with a response header 'X-Progress' containing a status message for the progress of the export job. When the job has finished, the polling location will return '200 OK', and the contents of the body will be a JSON object providing metadata and links to the generated bulk export data files.\n## Retrieving exported files\nThe JSON object returned when the export job is complete will contain a list of files (Binary resources) available for download. Each file can be retrieved using a standard HTTP GET request to the provided URL. The security context of the Binary resources resulting from the export is the user that initiated the export. The files can therefore only be retrieved by the same user.\n### Retention of exported files\nThe exported files are retained for a limited time after which they are deleted. The retention time is a server configuration with default 2 hours.\n",
+  "description": "FHIR Operation to initiate an export of data from a FHIR server. The type of resources returned can be restricted using the '_type' parameter, and the '_since' parameter can be used to restrict resources to be only included if changed since the supplied time. The FHIR server support invocation of this operation using the [FHIR Asynchronous Request Pattern](http://hl7.org/fhir/R4/async.html).\n## Initiation of export\nThe initiation of an export must specify the request header 'Prefer: respond-async', and will return '202 Accepted' with a polling location in the response header 'Content-Location'. The polling location is for the endpoint '$export-poll-status' and has the export job ID as parameter '_jobId'.\n### Parameters\n- _outputFormat: Optional parameter to specify the output format of the exported files. Default is 'application/fhir+ndjson'\n- _type: Optional parameter to specify a comma separated list of resource types to be included in the export. If not provided, all resource types will be included.\n- _since: Optional parameter to specify a time. Only resources that have been created or modified after this time will be included in the export (i.e., if Resource.meta.lastUpdated is later than the supplied _since time).\n- _until: Optional parameter to specify a time. Only resources that have been created or modified before this time will be included in the export (i.e., if Resource.meta.lastUpdated is earlier than the supplied _until time).\n- _typeFilter: Optional parameter to apply search filter of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied when searching resources.\n- _typePostFetchFilterUrl: Optional parameter to apply filtering of resources for export. It is a string of comma-delimited FHIR REST search queries in the format [resourceType]?[parameters]. The filter will be applied on resources after being fetched from the database.\n- _includeHistory: Optional parameter to specify whether historical versions of resources should be included in the export. Default is false.\n- _exportId: Optional parameter to specify a client provided identifier for the export. Resulting exported files (Binary) will be labeled with the identifer in meta extension 'https://hapifhir.org/NamingSystem/bulk-export-identifier'\n## Polling status of export\nSubsequent GET requests to the polling location will return '202 Accepted' with a response header 'X-Progress' containing a status message for the progress of the export job. When the job has finished, the polling location will return '200 OK', and the contents of the body will be a JSON object providing metadata and links to the generated bulk export data files.\n## Retrieving exported files\nThe JSON object returned when the export job is complete will contain a list of files (Binary resources) available for download. Each file can be retrieved using a standard HTTP GET request to the provided URL. The security context of the Binary resources resulting from the export is the user that initiated the export. The files can therefore only be retrieved by the same user.\n### Retention of exported files\nThe exported files are retained for a limited time after which they are deleted. The retention time is a server configuration with default 2 hours.\n",
   "affectsState": false,
   "code": "export",
   "system": true,
@@ -35,6 +35,13 @@
       "type": "instant"
     },
     {
+      "name": "_until",
+      "use": "in",
+      "min": 0,
+      "max": "1",
+      "type": "instant"
+    },
+    {
       "name": "_typeFilter",
       "use": "in",
       "min": 0,
@@ -54,6 +61,13 @@
       "min": 0,
       "max": "1",
       "type": "string"
+    },
+    {
+      "name": "_includeHistory",
+      "use": "in",
+      "min": 0,
+      "max": "1",
+      "type": "boolean"
     }
   ]
 }

--- a/input/resources/OperationDefinition--s-reindex.json
+++ b/input/resources/OperationDefinition--s-reindex.json
@@ -42,6 +42,29 @@
       "max": "1",
       "documentation": "Should we attempt to optimistically lock resources being reindexed in order to avoid concurrency issues (default: true)",
       "type": "boolean"
+    },
+    {
+      "name": "correctCurrentVersion",
+      "use": "in",
+      "min": 0,
+      "max": "1",
+      "documentation": "Should the indexer check and correct resources with an invalid current version pointer (default: NONE)",
+      "type": "code"
+    },
+    {
+      "name": "batchSize",
+      "use": "in",
+      "min": 0,
+      "max": "1",
+      "documentation": "How many resources should be reindexed in a single batch. This can be reduced if you need to reindex large resources and therefore need to reduce memory footprint. Values larger than 500 or less than 1 will be ignored (default: 500)",
+      "type": "integer"
+    },
+    {
+      "name": "partitionId",
+      "use": "in",
+      "min": 0,
+      "max": "*",
+      "type": "string"
     }
   ]
 }


### PR DESCRIPTION
- new bulk export parameters (_until, _includeHistory)
- expunge Binary for bulk export
- new reindex protocol (async)

- [ ] I have ensured the target branch is correct; for new changes, they target e.g. `release-3.5.0`. Only release branches should target `master`. For more details, see [here](../RELEASE.md).

The IG is materialised as a website automatically by CI, and can be found [here](http://build.fhir.org/ig/fut-infrastructure/implementation-guide/branches/).