### PR TITLE
[FUT1-22730] Renamed aggregateGroupId to follow naming conventions

### DIFF
--- a/input/fsh/ehealth-plandefinition.fsh
+++ b/input/fsh/ehealth-plandefinition.fsh
@@ -17,7 +17,7 @@ Parent: PlanDefinition
 * action.definition[x] only Canonical(ehealth-activitydefinition or ehealth-plandefinition)
 * action.extension contains ehealth-actionTrigger named ehealth-actionTrigger 0..1
 * action.extension contains ehealth-include-as-extra named includeAsExtra 0..1
-* action.extension contains ehealth-aggregate-group-id named aggregate-group-id 0..1
+* action.extension contains ehealth-aggregate-group-id named aggregateGroupId 0..1
 
 Extension: ehealth-actionTrigger
 Title:     "Action Trigger"


### PR DESCRIPTION
- [X] I have ensured the target branch is correct; for new changes, they target e.g. `release-3.5.0`. Only release branches should target `master`. For more details, see [here](../RELEASE.md).

The IG is materialised as a website automatically by CI, and can be found [here](http://build.fhir.org/ig/fut-infrastructure/implementation-guide/branches/).