### PR TITLE
FUT1-22618 - CCR0297 documentation and danish designation for two snomed code.

### DIFF
--- a/input/intro-notes/StructureDefinition-ehealth-condition-intro.md
+++ b/input/intro-notes/StructureDefinition-ehealth-condition-intro.md
@@ -15,4 +15,4 @@ The following PATCH operations are supported on the Condition resource:
 - For extension `codeQualification` the following PATCH operations are supported:
     - `add` and `replace`
 
-Note: when adding an extension for the first time, the extension property on the resource will not yet be initialized. Since extension is a list, its value must be provided as a JSON array.
+Note: when adding an `extension` for the first time, the `extension` property on the resource will not yet be initialized. Since `extension` is a list, its value must be provided as a JSON array.

--- a/input/intro-notes/StructureDefinition-ehealth-condition-intro.md
+++ b/input/intro-notes/StructureDefinition-ehealth-condition-intro.md
@@ -14,3 +14,5 @@ The following PATCH operations are supported on the Condition resource:
     - `add` and `replace`
 - For extension `codeQualification` the following PATCH operations are supported:
     - `add` and `replace`
+
+Note: if this is the first extension being added to a resource, the `extension` property will not yet be initialized. Since `extension` expects a list, the value must be provided as a JSON array.

--- a/input/intro-notes/StructureDefinition-ehealth-condition-intro.md
+++ b/input/intro-notes/StructureDefinition-ehealth-condition-intro.md
@@ -3,14 +3,14 @@ A Condition is a clinical condition, problem, diagnosis, or other event, situati
 
 # Scope and Usage
 
-### Supported Patch operations
-The following patch operations are supported on the Condition resource:
+### Supported PATCH operations
+The following PATCH operations are supported on the Condition resource:
 
-- For `verificationStatus` the following patch operations are supported:
+- For `verificationStatus` the following PATCH operations are supported:
     - `add`, `replace` and `remove`
-- For `clinicalStatus` the following patch operations are supported:
+- For `clinicalStatus` the following PATCH operations are supported:
     - `add` and `replace`
-- For `asserter` the following patch operations are supported:
+- For `asserter` the following PATCH operations are supported:
     - `add` and `replace`
-- For extension `codeQualification` the following patch operations are supported:
+- For extension `codeQualification` the following PATCH operations are supported:
     - `add` and `replace`

--- a/input/intro-notes/StructureDefinition-ehealth-condition-intro.md
+++ b/input/intro-notes/StructureDefinition-ehealth-condition-intro.md
@@ -15,4 +15,4 @@ The following PATCH operations are supported on the Condition resource:
 - For extension `codeQualification` the following PATCH operations are supported:
     - `add` and `replace`
 
-Note: if this is the first extension being added to a resource, the `extension` property will not yet be initialized. Since `extension` expects a list, the value must be provided as a JSON array.
+Note: when adding an extension for the first time, the extension property on the resource will not yet be initialized. Since extension is a list, its value must be provided as a JSON array.

--- a/input/intro-notes/StructureDefinition-ehealth-condition-intro.md
+++ b/input/intro-notes/StructureDefinition-ehealth-condition-intro.md
@@ -1,3 +1,16 @@
 # Introduction
 A Condition is a clinical condition, problem, diagnosis, or other event, situation, issue, or clinical concept that has risen to a level of concern.
 
+# Scope and Usage
+
+### Supported Patch operations
+The following patch operations are supported on the Condition resource:
+
+- For `verificationStatus` the following patch operations are supported:
+    - `add`, `replace` and `remove`
+- For `clinicalStatus` the following patch operations are supported:
+    - `add` and `replace`
+- For `asserter` the following patch operations are supported:
+    - `add` and `replace`
+- For extension `codeQualification` the following patch operations are supported:
+    - `add` and `replace`

--- a/input/intro-notes/StructureDefinition-ehealth-episodeofcare-intro.md
+++ b/input/intro-notes/StructureDefinition-ehealth-episodeofcare-intro.md
@@ -43,23 +43,23 @@ When performing a cross-team search, the following rules apply:
 - The condition codes provided as search parameters must be within the treatment areas of the telemedicine solution in which the Practitioner is operating
 - The search operation filters out any included or reverse-included resources (CarePlan and Condition) that are not allowed by the treatment areas of the telemedicine solution in which the Practitioner is operating
 
-### Supported Patch operations
-The following patch operations are supported on the EpisodeOfCare resource:
+### Supported PATCH operations
+The following PATCH operations are supported on the EpisodeOfCare resource:
 
-- For `diagnosis` the following patch operations are supported:
+- For `diagnosis` the following PATCH operations are supported:
     - `add`, `replace` and `move`
     - Note that `replace` is only allowed if no condition reference is removed.
-- For `status` the following patch operations are supported:
+- For `status` the following PATCH operations are supported:
     - `replace`
-- For `team` the following patch operations are supported:
+- For `team` the following PATCH operations are supported:
     - `add`, `replace` and `remove`
-- For `period` the following patch operations are supported:
+- For `period` the following PATCH operations are supported:
     - `replace`
-- For extension `caremanagerOrganization` the following patch operations are supported:
+- For extension `caremanagerOrganization` the following PATCH operations are supported:
     - `replace`
-- For extension `episodeofcareStatusschedule` the following patch operations are supported:
+- For extension `episodeofcareStatusschedule` the following PATCH operations are supported:
     - `add`, `replace` and `remove`
-- For extension `teamschedule` the following patch operations are supported:
+- For extension `teamschedule` the following PATCH operations are supported:
     - `add`, `replace` and `remove`
-- For extension `participant` the following patch operations are supported:
+- For extension `participant` the following PATCH operations are supported:
     - `add`, `replace` and `remove`

--- a/input/intro-notes/StructureDefinition-ehealth-episodeofcare-intro.md
+++ b/input/intro-notes/StructureDefinition-ehealth-episodeofcare-intro.md
@@ -42,3 +42,24 @@ When performing a cross-team search, the following rules apply:
 - The search must include the chained parameter `condition.code`, can be multiple codes
 - The condition codes provided as search parameters must be within the treatment areas of the telemedicine solution in which the Practitioner is operating
 - The search operation filters out any included or reverse-included resources (CarePlan and Condition) that are not allowed by the treatment areas of the telemedicine solution in which the Practitioner is operating
+
+### Supported Patch operations
+The following patch operations are supported on the EpisodeOfCare resource:
+
+- For `diagnosis` the following patch operations are supported:
+    - `add`, `replace` and `move`
+    - Note that `replace` is only allowed if no condition reference is removed.
+- For `status` the following patch operations are supported:
+    - `replace`
+- For `team` the following patch operations are supported:
+    - `add`, `replace` and `remove`
+- For `period` the following patch operations are supported:
+    - `replace`
+- For extension `caremanagerOrganization` the following patch operations are supported:
+    - `replace`
+- For extension `episodeofcareStatusschedule` the following patch operations are supported:
+    - `add`, `replace` and `remove`
+- For extension `teamschedule` the following patch operations are supported:
+    - `add`, `replace` and `remove`
+- For extension `participant` the following patch operations are supported:
+    - `add`, `replace` and `remove`

--- a/input/resources/CodeSystem-ehealth-supplement-snomed.info-sct.json
+++ b/input/resources/CodeSystem-ehealth-supplement-snomed.info-sct.json
@@ -32,6 +32,26 @@
           "value": "Billede af sår"
         }
       ]
+    },
+    {
+      "code": "225395003",
+      "display": "Wound assessment (procedure)",
+      "designation": [
+        {
+          "language": "da",
+          "value": "Sårvurdering"
+        }
+      ]
+    },
+    {
+      "code": "225358003",
+      "display": "Wound care (regime/therapy)",
+      "designation": [
+        {
+          "language": "da",
+          "value": "Sårbehandling og -pleje"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Added documentation for patch operations for Condition and EpisodeOfCare resources.

- [ ] I have ensured the target branch is correct; for new changes, they target e.g. `release-3.5.0`. Only release branches should target `master`. For more details, see [here](../RELEASE.md).

The IG is materialised as a website automatically by CI, and can be found [here](http://build.fhir.org/ig/fut-infrastructure/implementation-guide/branches/).