### PR TITLE
re-add poa privilege

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ The CI/CD pipeline uses the HL7 CI/CD infrastructure and Github webhooks which i
 
 ## Local development
 
+### Running SUSHI
+Use `./sushi.sh` instead of `npx sushi` to suppress known-safe naming warnings (ehealth-* names that don't follow PascalCase) while keeping all other output intact.
+
 ### Running locally
 Do `rm -rf output && rm -rf temp/ && ./_genonce.sh`
 

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -7,7 +7,9 @@ This is the log of changes made to the eHealth Implementation Guide.
 #### System operations
 #### Instance operations
 ### Code systems
+- Re-added `http://ehealth.sundhed.dk/cs/poa-privilege` (Power of Attorney Privilege) CodeSystem. Content is `not-present` — codes are vendor-specific and externally governed.
 ### ValueSets
+- Re-added `http://ehealth.sundhed.dk/cs/poa-privilege` as an include in `http://ehealth.sundhed.dk/vs/relatedperson-relationshiptype`.
 ### ConceptMaps
 ### Resource/profile changes
 - Updated ehealth-media to allow patient and relatedPerson references in it's operator field.

--- a/input/resources/CodeSystem-ehealth-poa-privilege.json
+++ b/input/resources/CodeSystem-ehealth-poa-privilege.json
@@ -1,0 +1,25 @@
+{
+  "resourceType": "CodeSystem",
+  "id": "ehealth-poa-privilege",
+  "url": "http://ehealth.sundhed.dk/cs/poa-privilege",
+  "version": "0.0.1",
+  "name": "PoAPrivilege",
+  "title": "Power of Attorney Privilege",
+  "status": "active",
+  "experimental": false,
+  "date": "2026-03-24T00:00:00+00:00",
+  "publisher": "ehealth.sundhed.dk",
+  "contact": [
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://ehealth.sundhed.dk/terminology"
+        }
+      ]
+    }
+  ],
+  "description": "Vendor-specific power of attorney privilege codes used by Keycloak when creating RelatedPerson resources for PoA-authenticated citizens. The full set of codes is externally governed and not enumerated here.",
+  "caseSensitive": true,
+  "content": "not-present"
+}

--- a/input/resources/ValueSet-ehealth-relatedperson-relationshiptype.json
+++ b/input/resources/ValueSet-ehealth-relatedperson-relationshiptype.json
@@ -24,7 +24,8 @@
       { "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode", "code": "O",        "display": "Operator Proficiency" },
       { "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode", "code": "CHILD",    "display": "child" },
       { "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode", "code": "SPS",      "display": "spouse" },
-      { "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode", "code": "POWATT",   "display": "power of attorney" }
+      { "system": "http://terminology.hl7.org/CodeSystem/v3-RoleCode", "code": "POWATT",   "display": "power of attorney" },
+      { "system": "http://ehealth.sundhed.dk/cs/poa-privilege", "abstract": true, "display": "Vendor-specific PoA privilege codes (externally governed, not enumerated)" }
     ]
   },
   "compose": {
@@ -72,6 +73,9 @@
             "code": "POWATT"
           }
         ]
+      },
+      {
+        "system": "http://ehealth.sundhed.dk/cs/poa-privilege"
       }
     ]
   }

--- a/sushi.sh
+++ b/sushi.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Runs SUSHI and filters out known-safe naming warnings for ehealth-* slice names.
+# Use 'npx sushi' directly if you want unfiltered output.
+FORCE_COLOR=1 npx sushi "$@" 2>&1 | sed '/Valid names start with an upper-case ASCII letter/{N;N;d}'


### PR DESCRIPTION
- [ ] I have ensured the target branch is correct; for new changes, they target e.g. `release-3.5.0`. Only release branches should target `master`. For more details, see [here](../RELEASE.md).

The IG is materialised as a website automatically by CI, and can be found [here](http://build.fhir.org/ig/fut-infrastructure/implementation-guide/branches/).