### PR TITLE
[(CCR0281_update_provenance_policy)] Renamed aggregate-input code to …

### DIFF
--- a/input/resources/CodeSystem-ehealth-ehealth-provenance-policies.json
+++ b/input/resources/CodeSystem-ehealth-ehealth-provenance-policies.json
@@ -53,7 +53,7 @@
       ]
     },
     {
-      "code": "aggregate-input",
+      "code": "http://ehealth.sundhed.dk/policy/dk/aggregate-input",
       "display": "Aggregated Triage Input",
       "designation": [
         {


### PR DESCRIPTION
…include http://ehealth.sundhed.dk/policy/ehealth/ per convention

- [X] I have ensured the target branch is correct; for new changes, they target e.g. `release-3.5.0`. Only release branches should target `master`. For more details, see [here](../RELEASE.md).

The IG is materialised as a website automatically by CI, and can be found [here](http://build.fhir.org/ig/fut-infrastructure/implementation-guide/branches/).