### PR TITLE
refactor(ehealth-carecommunication): extract CS/VS and fix profile issues

### DIFF
--- a/input/fsh/ehealth-carecommunication.fsh
+++ b/input/fsh/ehealth-carecommunication.fsh
@@ -1,15 +1,9 @@
-// comment for later:
-// The note "should also exist in the MedcomCareCommunicationMessage bundle" is a packaging rule—consider documenting
-// this in your IG narrative, as you can't force presence in a different Bundle with profile alone.
-
-
 Profile: ehealth-carecommunication
 Id: ehealth-carecommunication
 Parent: Communication
 
 * obeys
     stopped-status-statusReason
-    and only-asap-or-routine
     and topic-required-when-category-other
     and priority-category-invariant
     and atLeastOnePayloadString
@@ -41,6 +35,8 @@ Parent: Communication
 
 * status 1..1 MS
 
+* statusReason from http://ehealth.sundhed.dk/vs/ehealth-carecommunication-status-reason (required)
+
 * category 1..1 MS
 * category from http://ehealth.sundhed.dk/vs/ehealth-carecommunication-category (required)
 * category.coding 1..1 MS
@@ -71,15 +67,16 @@ Parent: Communication
 
 * extension contains ehealth-carecommunication-origin named origin 1..1 MS
 
-* extension contains ehealth-carecommunication-message-Type named messageType 1..1 MS
+* extension contains ehealth-carecommunication-message-type named messageType 1..1 MS
 
 * recipient 0..1
 * recipient only Reference(CareTeam or PractitionerRole)
 * recipient MS
-* recipient ^short = "The recieving actor of the message"
+* recipient ^short = "The receiving actor of the message"
 
 * inResponseTo 0..1 MS
-* inResponseTo ^short = "references the Ehealth-CareCommunication Communication.id, which this message is a response to."
+* inResponseTo only Reference(ehealth-carecommunication)
+* inResponseTo ^short = "Reference to the previous ehealth-carecommunication resource this message is a response to."
 
 * sender 0..0
 
@@ -117,6 +114,7 @@ Parent: Communication
 * payload[attachment].contentAttachment.creation MS
 * payload[attachment].contentAttachment.creation ^short = "The time the attachment was created"
 
+
 // Extensions
 
 Extension: ehealth-carecommunication-sender
@@ -145,124 +143,33 @@ Description: "Reference to the destination Organization for this communication."
 * value[x] only Reference(Organization)
 
 Extension: ehealth-carecommunication-datetime
+Id: ehealth-carecommunication-datetime
 Title: "DateTime Extension"
 Description: "Date and time of the payload segment."
 * . ^short = "Payload dateTime"
 * value[x] only dateTime
 
 Extension: ehealth-carecommunication-payload-identifier
+Id: ehealth-carecommunication-payload-identifier
 Title: "Identifier Extension"
 Description: "Extension to hold an Identifier for a payload. Identifier.value shall be a UUID v4 in URN form (urn:uuid:<uuid>)."
 * value[x] only Identifier
 * valueIdentifier 1..1
 
 Extension: ehealth-carecommunication-origin
-Title: "sender organization"
+Id: ehealth-carecommunication-origin
+Title: "Sender organization"
 Description: "Reference to the sending organization for this payload segment."
 * . ^short = "Reference to the sending organization of the message"
 * value[x] only Reference(Organization)
 
-Extension: ehealth-carecommunication-message-Type
+Extension: ehealth-carecommunication-message-type
+Id: ehealth-carecommunication-message-type
 Title: "Message type"
 Description: "The type of the message. If inResponseTo is present, the type can not be new-message."
 * value[x] only Coding
-* valueCoding from MessageType (required)
+* valueCoding from http://ehealth.sundhed.dk/vs/ehealth-carecommunication-message-type (required)
 * . ^short = "Message type"
-
-// Valuesets
-
-ValueSet: MessageType
-Title: "Message Type ValueSet"
-Description: "Allowed message types: new-message, reply-message, forward-message."
-* ^url = "http://ehealth.sundhed.dk/vs/ehealth-carecommunication-message-type"
-* ^compose.include.system = "http://ehealth.sundhed.dk/cs/message-type"
-* ^compose.include.concept[+].code = #new-message
-* ^compose.include.concept[=].display = "New Message"
-* ^compose.include.concept[+].code = #reply-message
-* ^compose.include.concept[=].display = "Reply Message"
-* ^compose.include.concept[+].code = #forward-message
-* ^compose.include.concept[=].display = "Forward Message"
-
-ValueSet: EhealthCareCommunicationCategoryVS
-Id: ehealth-carecommunication-category
-Title: "eHealth CareCommunication Categories"
-* ^url = "http://ehealth.sundhed.dk/vs/ehealth-carecommunication-category"
-* ^status = #active
-* ^description = "Categories used for CareCommunciation messages."
-* ^compose.include.system = "http://ehealth.sundhed.dk/cs/ehealth-carecommunication-category"
-
-ValueSet: EhealthCareCommunicationMimeTypesVS
-Id: ehealth-carecommunication-mimetypes
-Title: "eHealth CareCommunication Attachment MIME Types"
-Description: "Allowed MIME types for attachments in eHealth CareCommunication messages. Mirrors MedCom's medcom-core-attachmentMimeTypes ValueSet."
-* ^url = "http://ehealth.sundhed.dk/vs/ehealth-carecommunication-mimetypes"
-* ^status = #active
-* ^compose.include.system = "urn:ietf:bcp:13"
-* ^compose.include.concept[+].code = #application/pdf
-* ^compose.include.concept[=].display = "application/pdf"
-* ^compose.include.concept[+].code = #image/gif
-* ^compose.include.concept[=].display = "image/gif"
-* ^compose.include.concept[+].code = #image/jpeg
-* ^compose.include.concept[=].display = "image/jpeg"
-* ^compose.include.concept[+].code = #image/png
-* ^compose.include.concept[=].display = "image/png"
-* ^compose.include.concept[+].code = #image/tiff
-* ^compose.include.concept[=].display = "image/tiff"
-* ^compose.include.concept[+].code = #image/bmp
-* ^compose.include.concept[=].display = "image/bmp"
-
-ValueSet: EhealthCareCommunicationPriorityVS
-Id: ehealth-carecommunication-priority
-Title: "eHealth CareCommunication Priorities"
-* ^url = "http://ehealth.sundhed.dk/vs/ehealth-carecommunication-priority"
-* ^status = #active
-* ^description = "Priorities used for CareCommunication messages."
-* ^compose.include.system = "http://ehealth.sundhed.dk/cs/ehealth-carecommunication-priority"
-
-
-// CodeSystems
-
-CodeSystem: MessageTypeCS
-Title: "Message Type CodeSystem"
-Description: "Allowed codes for message type."
-* ^url = "http://ehealth.sundhed.dk/cs/message-type"
-* #new-message "New Message"
-* #reply-message "Reply"
-* #forward-message "Forward"
-
-CodeSystem: EhealthCareCommunicationCategoryCS
-Id: ehealth-carecommunication-category
-Title: "eHealth CareCommunication Category codes"
-Description: "The set of CareCommunication category code."
-* ^url = "http://ehealth.sundhed.dk/cs/ehealth-carecommunication-category"
-* #alcohol-and-drug-treatment "Alcohol and drug treatment"
-* #assistive-devices "Assistive technology"
-* #carecoordination "Care Coordination"
-* #decease "Decease"
-* #discharge "Discharge"
-* #examination-results "Examination Results"
-* #healthcare "Healthcare"
-* #home-care-assessment "Home care assessment"
-* #medicine "Medicine"
-* #nursing "Nursing"
-* #outpatient "Outpatient"
-* #psychiatry-social-disability "Psychiatry, Social, Disability"
-* #regarding-referral "Regarding Referral"
-* #telemedicine "Telemedicine"
-* #training "Training"
-* #acute-ambulant "Acute ambulant"
-* #extended-care-responsibility "Extended care responsibility"
-* #other "Other"
-
-CodeSystem: EhealthCareCommunicationPriorityCS
-Id: ehealth-carecommunication-priority
-Title: "eHealth CareCommunication Priority codes"
-Description: "The set of CareCommunication priority code."
-* ^url = "http://ehealth.sundhed.dk/cs/ehealth-carecommunication-priority"
-* #routine "Routine"
-* #asap "ASAP"
-
-
 
 
 // Invariants
@@ -272,14 +179,9 @@ Description: "If status is 'stopped', statusReason must be either 'system-error'
 Expression: "status != 'stopped' or statusReason.coding.where(code = 'system-error' or code = 'recipient-unavailable').exists()"
 Severity: #error
 
-Invariant: only-asap-or-routine
-Description: "priority must be either 'asap' or 'routine'"
-Expression: "priority.empty() or priority = 'asap' or priority = 'routine'"
-Severity: #error
-
 Invariant: topic-required-when-category-other
 Description: "topic must be present when category is 'other'."
-Expression: "iif(category.coding.code != 'other', true, category.coding.code = 'other' and topic.exists())"
+Expression: "category.coding.code != 'other' or topic.exists()"
 Severity: #error
 
 Invariant: priority-category-invariant
@@ -299,7 +201,7 @@ Severity: #error
 
 Invariant: payloadAttachment-contentType-required
 Description: "contentType SHALL be present if data or url is present in Attachment"
-Expression: "payload.contentAttachment.data.exists() or payload.contentAttachment.url.exists() implies payload.contentAttachment.contentType.exists()"
+Expression: "(payload.contentAttachment.data.exists() or payload.contentAttachment.url.exists()) implies payload.contentAttachment.contentType.exists()"
 Severity: #error
 
 Invariant: no-standard-sender
@@ -309,13 +211,10 @@ Severity: #error
 
 Invariant: reply-requires-inResponseTo
 Description: "If messageType is 'reply-message', inResponseTo SHALL be populated."
-Expression: "extension('http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-carecommunication-message-Type').value.where(code = 'reply-message').exists() implies inResponseTo.exists()"
+Expression: "extension('http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-carecommunication-message-type').value.where(code = 'reply-message').exists() implies inResponseTo.exists()"
 Severity: #error
 
 Invariant: sender-required-based-on-messagetype
-Description: """
-If messagetype is 'new' or 'reply', the sender extension must be present.
-If 'forward', sender may be absent.
-"""
-Expression: "extension('http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-carecommunication-message-Type').value.where(code = 'new-message' or code = 'reply-message').exists() implies extension('http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-carecommunication-sender').exists()"
+Description: "If messageType is 'new-message' or 'reply-message', the sender extension must be present. For 'forward-message', sender may be absent."
+Expression: "extension('http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-carecommunication-message-type').value.where(code = 'new-message' or code = 'reply-message').exists() implies extension('http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-carecommunication-sender').exists()"
 Severity: #error

--- a/input/fsh/ehealth-carecommunication.fsh
+++ b/input/fsh/ehealth-carecommunication.fsh
@@ -35,8 +35,6 @@ Parent: Communication
 
 * status 1..1 MS
 
-* statusReason from http://ehealth.sundhed.dk/vs/ehealth-carecommunication-status-reason (required)
-
 * category 1..1 MS
 * category from http://ehealth.sundhed.dk/vs/ehealth-carecommunication-category (required)
 * category.coding 1..1 MS
@@ -67,7 +65,7 @@ Parent: Communication
 
 * extension contains ehealth-carecommunication-origin named origin 1..1 MS
 
-* extension contains ehealth-carecommunication-message-type named messageType 1..1 MS
+* extension contains ehealth-carecommunication-message-Type named messageType 1..1 MS
 
 * recipient 0..1
 * recipient only Reference(CareTeam or PractitionerRole)
@@ -75,7 +73,6 @@ Parent: Communication
 * recipient ^short = "The receiving actor of the message"
 
 * inResponseTo 0..1 MS
-* inResponseTo only Reference(ehealth-carecommunication)
 * inResponseTo ^short = "Reference to the previous ehealth-carecommunication resource this message is a response to."
 
 * sender 0..0
@@ -163,8 +160,8 @@ Description: "Reference to the sending organization for this payload segment."
 * . ^short = "Reference to the sending organization of the message"
 * value[x] only Reference(Organization)
 
-Extension: ehealth-carecommunication-message-type
-Id: ehealth-carecommunication-message-type
+Extension: ehealth-carecommunication-message-Type
+Id: ehealth-carecommunication-message-Type
 Title: "Message type"
 Description: "The type of the message. If inResponseTo is present, the type can not be new-message."
 * value[x] only Coding
@@ -211,10 +208,10 @@ Severity: #error
 
 Invariant: reply-requires-inResponseTo
 Description: "If messageType is 'reply-message', inResponseTo SHALL be populated."
-Expression: "extension('http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-carecommunication-message-type').value.where(code = 'reply-message').exists() implies inResponseTo.exists()"
+Expression: "extension('http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-carecommunication-message-Type').value.where(code = 'reply-message').exists() implies inResponseTo.exists()"
 Severity: #error
 
 Invariant: sender-required-based-on-messagetype
 Description: "If messageType is 'new-message' or 'reply-message', the sender extension must be present. For 'forward-message', sender may be absent."
-Expression: "extension('http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-carecommunication-message-type').value.where(code = 'new-message' or code = 'reply-message').exists() implies extension('http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-carecommunication-sender').exists()"
+Expression: "extension('http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-carecommunication-message-Type').value.where(code = 'new-message' or code = 'reply-message').exists() implies extension('http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-carecommunication-sender').exists()"
 Severity: #error

--- a/input/fsh/ehealth-codesystem-carecommunication.fsh
+++ b/input/fsh/ehealth-codesystem-carecommunication.fsh
@@ -1,0 +1,48 @@
+CodeSystem: MessageTypeCS
+Id: ehealth-carecommunication-message-type
+Title: "Message Type CodeSystem"
+Description: "Allowed codes for message type."
+* ^url = "http://ehealth.sundhed.dk/cs/message-type"
+* #new-message "New Message"
+* #reply-message "Reply"
+* #forward-message "Forward"
+
+CodeSystem: EhealthCareCommunicationCategoryCS
+Id: ehealth-carecommunication-category
+Title: "eHealth CareCommunication Category codes"
+Description: "The set of CareCommunication category codes."
+* ^url = "http://ehealth.sundhed.dk/cs/ehealth-carecommunication-category"
+* #alcohol-and-drug-treatment "Alcohol and drug treatment"
+* #assistive-devices "Assistive technology"
+* #carecoordination "Care Coordination"
+* #decease "Decease"
+* #discharge "Discharge"
+* #examination-results "Examination Results"
+* #healthcare "Healthcare"
+* #home-care-assessment "Home care assessment"
+* #medicine "Medicine"
+* #nursing "Nursing"
+* #outpatient "Outpatient"
+* #psychiatry-social-disability "Psychiatry, Social, Disability"
+* #regarding-referral "Regarding Referral"
+* #telemedicine "Telemedicine"
+* #training "Training"
+* #acute-ambulant "Acute ambulant"
+* #extended-care-responsibility "Extended care responsibility"
+* #other "Other"
+
+CodeSystem: EhealthCareCommunicationPriorityCS
+Id: ehealth-carecommunication-priority
+Title: "eHealth CareCommunication Priority codes"
+Description: "The set of CareCommunication priority codes."
+* ^url = "http://ehealth.sundhed.dk/cs/ehealth-carecommunication-priority"
+* #routine "Routine"
+* #asap "ASAP"
+
+CodeSystem: EhealthCareCommunicationStatusReasonCS
+Id: ehealth-carecommunication-status-reason
+Title: "eHealth CareCommunication Status Reason codes"
+Description: "Codes that explain why a CareCommunication message was stopped."
+* ^url = "http://ehealth.sundhed.dk/cs/ehealth-carecommunication-status-reason"
+* #system-error "System error"
+* #recipient-unavailable "Recipient unavailable"

--- a/input/fsh/ehealth-relatedperson.fsh
+++ b/input/fsh/ehealth-relatedperson.fsh
@@ -12,7 +12,7 @@ Parent: RelatedPerson
 
 * patient only Reference(ehealth-patient)
 * patient ^type.aggregation = #referenced
-* relationship.coding from http://ehealth.sundhed.dk/vs/relatedperson-relationshiptype (extensible)
+* relationship.coding from http://ehealth.sundhed.dk/vs/relatedperson-relationshiptype (required)
 * name 1..*
 
 Instance: relatedperson01

--- a/input/fsh/ehealth-valueset-carecommunication.fsh
+++ b/input/fsh/ehealth-valueset-carecommunication.fsh
@@ -1,0 +1,56 @@
+ValueSet: MessageType
+Id: ehealth-carecommunication-message-type
+Title: "Message Type ValueSet"
+Description: "Allowed message types: new-message, reply-message, forward-message."
+* ^url = "http://ehealth.sundhed.dk/vs/ehealth-carecommunication-message-type"
+* ^compose.include.system = "http://ehealth.sundhed.dk/cs/message-type"
+* ^compose.include.concept[+].code = #new-message
+* ^compose.include.concept[=].display = "New Message"
+* ^compose.include.concept[+].code = #reply-message
+* ^compose.include.concept[=].display = "Reply Message"
+* ^compose.include.concept[+].code = #forward-message
+* ^compose.include.concept[=].display = "Forward Message"
+
+ValueSet: EhealthCareCommunicationCategoryVS
+Id: ehealth-carecommunication-category
+Title: "eHealth CareCommunication Categories"
+* ^url = "http://ehealth.sundhed.dk/vs/ehealth-carecommunication-category"
+* ^status = #active
+* ^description = "Categories used for CareCommunication messages."
+* ^compose.include.system = "http://ehealth.sundhed.dk/cs/ehealth-carecommunication-category"
+
+ValueSet: EhealthCareCommunicationMimeTypesVS
+Id: ehealth-carecommunication-mimetypes
+Title: "eHealth CareCommunication Attachment MIME Types"
+Description: "Allowed MIME types for attachments in eHealth CareCommunication messages. Mirrors MedCom's medcom-core-attachmentMimeTypes ValueSet."
+* ^url = "http://ehealth.sundhed.dk/vs/ehealth-carecommunication-mimetypes"
+* ^status = #active
+* ^compose.include.system = "urn:ietf:bcp:13"
+* ^compose.include.concept[+].code = #application/pdf
+* ^compose.include.concept[=].display = "application/pdf"
+* ^compose.include.concept[+].code = #image/gif
+* ^compose.include.concept[=].display = "image/gif"
+* ^compose.include.concept[+].code = #image/jpeg
+* ^compose.include.concept[=].display = "image/jpeg"
+* ^compose.include.concept[+].code = #image/png
+* ^compose.include.concept[=].display = "image/png"
+* ^compose.include.concept[+].code = #image/tiff
+* ^compose.include.concept[=].display = "image/tiff"
+* ^compose.include.concept[+].code = #image/bmp
+* ^compose.include.concept[=].display = "image/bmp"
+
+ValueSet: EhealthCareCommunicationPriorityVS
+Id: ehealth-carecommunication-priority
+Title: "eHealth CareCommunication Priorities"
+* ^url = "http://ehealth.sundhed.dk/vs/ehealth-carecommunication-priority"
+* ^status = #active
+* ^description = "Priorities used for CareCommunication messages."
+* ^compose.include.system = "http://ehealth.sundhed.dk/cs/ehealth-carecommunication-priority"
+
+ValueSet: EhealthCareCommunicationStatusReasonVS
+Id: ehealth-carecommunication-status-reason
+Title: "eHealth CareCommunication Status Reasons"
+* ^url = "http://ehealth.sundhed.dk/vs/ehealth-carecommunication-status-reason"
+* ^status = #active
+* ^description = "Reasons a CareCommunication message was stopped."
+* ^compose.include.system = "http://ehealth.sundhed.dk/cs/ehealth-carecommunication-status-reason"

--- a/input/intro-notes/StructureDefinition-ehealth-carecommunication-intro.md
+++ b/input/intro-notes/StructureDefinition-ehealth-carecommunication-intro.md
@@ -2,7 +2,7 @@
 
 An Ehealth-CareCommunication is an FUT abstraction of a MedCom CareCommunication.
 This is needed to support communication through the VANS network with parties outside the FUT infrastructure, as well as inside FUT.
-The Ehealth-CareCommunication's primary feature is to enable communication in relation to several images of different file types.
+The Ehealth-CareCommunication supports text and attachment-based clinical communication (including documents and images) between healthcare parties over the VANS network.
 
 # Remarks about status and administrative-status
 
@@ -53,6 +53,6 @@ have a PractitionerRole representing that message.
 - The Communication identifier is the same for all Ehealth-CareCommunications of the same conversation. A new Communication Id is needed for a Forward message type, even though bundles from a prior conversation are included.
 - The MessageHeader identifier is set for received messages, as client-side assignment of id's is not possible. For messages sent from the FUT infrastructure, it is not needed. 
 The reasoning for the use of this identifier is that the correlating MedCom model for Ehealth-CareCommunications identifies specific messages based on the MessageHeader identifier.
-- inResponseTo has to be included for Reply messages. It points to the previous MessageHeader identifier in the conversation if present, otherwise Ehealth-CareCommunication.id.
+- inResponseTo has to be included for Reply messages. It references the previous ehealth-carecommunication resource in the conversation.
 - If category is other, the topic.text element has to be populated.
 - recipient can be excluded, which means the message is considered sent to the destination organization.

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -3,23 +3,16 @@ This is the log of changes made to the eHealth Implementation Guide.
 ## Release 2026.3
 ### General changes
 - Updated ehealth-media to allow patient and relatedPerson references in its operator field.
-- Updated ehealth-relatedperson relationship binding from `required` to `extensible` to accommodate vendor-specific PoA privilege codes.
 ### Custom operations
 #### System operations
 #### Instance operations
-- Added `Appointment/$send-message` instance operation for sending SMS messages to related persons associated with an appointment (CCR0316).
 ### Code systems
 - Re-added `http://ehealth.sundhed.dk/cs/poa-privilege` (Power of Attorney Privilege) CodeSystem. Content is `not-present` — codes are vendor-specific and externally governed.
-- Added `http://ehealth.sundhed.dk/cs/telecom-purpose` for telecom contact point purpose codes.
-- Added `http://ehealth.sundhed.dk/cs/ehealth-message-channel` for message channel codes (e.g. SMS).
 ### ValueSets
 - Re-added `http://ehealth.sundhed.dk/cs/poa-privilege` as an include in `http://ehealth.sundhed.dk/vs/relatedperson-relationshiptype`.
-- Added `http://ehealth.sundhed.dk/vs/telecom-purpose`.
-- Added `http://ehealth.sundhed.dk/vs/ehealth-message-channel`.
 ### ConceptMaps
 ### Resource/profile changes
 - Updated ehealth-media to allow patient and relatedPerson references in its operator field.
-- Added `video-appointment-reminder-sms` telecom slice on `ehealth-relatedperson` for storing the SMS number used for video appointment reminders to related persons (CCR0316).
 
 ### Event messages
 - Tightened the `EHealthApplicationEvent` JSON schema (CCR0303 AC-7): the schema is now declared as JSON Schema draft-07; `eventType` and `resourceReference` are top-level required; `resourceReference` requires `minItems: 1` with each entry requiring both `label` and `reference`; and per-`eventType` `if`/`then`/`contains` rules assert the obligatory `resourceReference.label`. **Note for vendors:** producers must now emit both `label` and `reference` on every `resourceReference` entry and include the `eventType`-specific obligatory label.

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -1,35 +1,44 @@
 This is the log of changes made to the eHealth Implementation Guide.
 
-## Release 2026.3. todo: change to semver format before release
+## Release 2026.3
 ### General changes
-- Updated ehealth-media to allow patient and relatedPerson references in it's operator field.
+- Updated ehealth-media to allow patient and relatedPerson references in its operator field.
+- Updated ehealth-relatedperson relationship binding from `required` to `extensible` to accommodate vendor-specific PoA privilege codes.
 ### Custom operations
 #### System operations
 #### Instance operations
+- Added `Appointment/$send-message` instance operation for sending SMS messages to related persons associated with an appointment (CCR0316).
 ### Code systems
 - Re-added `http://ehealth.sundhed.dk/cs/poa-privilege` (Power of Attorney Privilege) CodeSystem. Content is `not-present` — codes are vendor-specific and externally governed.
+- Added `http://ehealth.sundhed.dk/cs/telecom-purpose` for telecom contact point purpose codes.
+- Added `http://ehealth.sundhed.dk/cs/ehealth-message-channel` for message channel codes (e.g. SMS).
 ### ValueSets
 - Re-added `http://ehealth.sundhed.dk/cs/poa-privilege` as an include in `http://ehealth.sundhed.dk/vs/relatedperson-relationshiptype`.
+- Added `http://ehealth.sundhed.dk/vs/telecom-purpose`.
+- Added `http://ehealth.sundhed.dk/vs/ehealth-message-channel`.
 ### ConceptMaps
 ### Resource/profile changes
-- Updated ehealth-media to allow patient and relatedPerson references in it's operator field.
+- Updated ehealth-media to allow patient and relatedPerson references in its operator field.
+- Added `video-appointment-reminder-sms` telecom slice on `ehealth-relatedperson` for storing the SMS number used for video appointment reminders to related persons (CCR0316).
 
 ### Event messages
 - Tightened the `EHealthApplicationEvent` JSON schema (CCR0303 AC-7): the schema is now declared as JSON Schema draft-07; `eventType` and `resourceReference` are top-level required; `resourceReference` requires `minItems: 1` with each entry requiring both `label` and `reference`; and per-`eventType` `if`/`then`/`contains` rules assert the obligatory `resourceReference.label`. **Note for vendors:** producers must now emit both `label` and `reference` on every `resourceReference` entry and include the `eventType`-specific obligatory label.
 
-## 9.0.2-SNAPSHOT (2026-05-04)
+## 9.0.2-SNAPSHOT (2026-05-12)
 ### Code systems
 - Added http://ehealth.sundhed.dk/cs/ehealth-carecommunication-category for CareCommunication category codes.
 - Added http://ehealth.sundhed.dk/cs/ehealth-carecommunication-priority for CareCommunication priority codes.
 - Added http://ehealth.sundhed.dk/cs/message-type for CareCommunication message types (new-message, reply-message, forward-message).
+- Added http://ehealth.sundhed.dk/cs/ehealth-carecommunication-status-reason for CareCommunication stopped-status reason codes (system-error, recipient-unavailable).
 ### ValueSets
 - Added http://ehealth.sundhed.dk/vs/ehealth-carecommunication-category.
 - Added http://ehealth.sundhed.dk/vs/ehealth-carecommunication-priority.
 - Added http://ehealth.sundhed.dk/vs/ehealth-carecommunication-mimetypes for allowed CareCommunication attachment MIME types.
-- Added MessageType ValueSet for CareCommunication message types.
+- Added http://ehealth.sundhed.dk/vs/ehealth-carecommunication-message-type for CareCommunication message types.
+- Added http://ehealth.sundhed.dk/vs/ehealth-carecommunication-status-reason for CareCommunication stopped-status reason codes.
 ### ConceptMaps
 - Added ConceptMap CareCommunication-Priority mapping CareCommunication priorities to MedCom equivalents.
-- Added ConceptMap CareCommunucation-Category mapping CareCommunication categories to MedCom equivalents.
+- Added ConceptMap CareCommunication-Category mapping CareCommunication categories to MedCom equivalents.
 ### Resource/profile changes
 - Added new `ehealth-carecommunication` Communication profile with extensions for sender (PractitionerRole, Practitioner, optional CareTeam and ContactPoint), destination Organization, origin Organization, payload datetime, payload identifier, and message type.
 
@@ -638,8 +647,7 @@ This is the log of changes made to the eHealth Implementation Guide.
 ## 2.7.0 (2023-03-29)
 
 ### General changes
-- Changed the description in section "Automatic NemSMS Notifications" for Ehealth-message. This is related to "CCR0167 Ingen automatisk NemSMS for ehealth-message med kategori message" from 
-13.
+- Changed the description in section "Automatic NemSMS Notifications" for Ehealth-message. This is related to "CCR0167 Ingen automatisk NemSMS for ehealth-message med kategori message" from Release 13.
 - Changed the descriptions of ehealth-message category to reflect CCR0154 changes.
 ### Custom operations
 #### System operations

--- a/input/resources/ConceptMap-CareCommunication-Category.json
+++ b/input/resources/ConceptMap-CareCommunication-Category.json
@@ -8,7 +8,7 @@
   "group": [
     {
       "source": "http://ehealth.sundhed.dk/cs/ehealth-carecommunication-category",
-      "target": "http://medcomfhir.dk/ig/terminology/ValueSet/medcom-careCommunication-categories",
+      "target": "http://medcomfhir.dk/ig/terminology/CodeSystem/medcom-careCommunication-categories",
       "element": [
         {
           "code": "alcohol-and-drug-treatment",

--- a/input/resources/ConceptMap-CareCommunication-Category.json
+++ b/input/resources/ConceptMap-CareCommunication-Category.json
@@ -8,7 +8,7 @@
   "group": [
     {
       "source": "http://ehealth.sundhed.dk/cs/ehealth-carecommunication-category",
-      "target": "http://medcomfhir.dk/ig/terminology/CodeSystem/medcom-careCommunication-categories",
+      "target": "http://medcomfhir.dk/ig/terminology/ValueSet/medcom-careCommunication-categories",
       "element": [
         {
           "code": "alcohol-and-drug-treatment",

--- a/input/resources/ConceptMap-CareCommunication-Priority.json
+++ b/input/resources/ConceptMap-CareCommunication-Priority.json
@@ -8,7 +8,7 @@
   "group": [
     {
       "source": "http://ehealth.sundhed.dk/cs/ehealth-carecommunication-priority",
-      "target": "http://medcomfhir.dk/ig/terminology/CodeSystem/medcom-careCommunication-requestPriority",
+      "target": "http://medcomfhir.dk/ig/terminology/ValueSet/medcom-careCommunication-requestPriority",
       "element": [
         {
           "code": "routine",

--- a/input/resources/ConceptMap-CareCommunication-Priority.json
+++ b/input/resources/ConceptMap-CareCommunication-Priority.json
@@ -8,7 +8,7 @@
   "group": [
     {
       "source": "http://ehealth.sundhed.dk/cs/ehealth-carecommunication-priority",
-      "target": "http://medcomfhir.dk/ig/terminology/ValueSet/medcom-careCommunication-requestPriority",
+      "target": "http://medcomfhir.dk/ig/terminology/CodeSystem/medcom-careCommunication-requestPriority",
       "element": [
         {
           "code": "routine",

--- a/sushi.sh
+++ b/sushi.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # Runs SUSHI and filters out known-safe naming warnings for ehealth-* slice names.
 # Use 'npx sushi' directly if you want unfiltered output.
-FORCE_COLOR=1 npx sushi "$@" 2>&1 | sed '/Valid names start with an upper-case ASCII letter/{N;N;d}'
+FORCE_COLOR=1 npx sushi "$@" 2>&1 | grep -v "Valid names start with an upper-case ASCII letter"


### PR DESCRIPTION
## Summary

Split out from #282 so CCR0316 and the carecommunication cleanup can be reviewed independently.

### Profile changes
- Extract CareCommunication CodeSystems and ValueSets into dedicated FSH files (`ehealth-codesystem-carecommunication.fsh`, `ehealth-valueset-carecommunication.fsh`).
- Add `ehealth-carecommunication-status-reason` CS + VS documenting the valid stopped-status reason codes (`system-error`, `recipient-unavailable`). The existing `stopped-status-statusReason` invariant remains the enforcing constraint; the CS/VS are kept for discoverability.
- Remove the redundant `only-asap-or-routine` invariant (already covered by `priority-category-invariant`).
- Add explicit `Id` fields to the carecommunication extensions.
- Simplify `topic-required-when-category-other` (`iif(...)` → logical `or`) and add clarifying parens around the `payloadAttachment-contentType-required` precondition.
- Rename `MessageType` ValueSet id to `ehealth-carecommunication-message-type` and align the binding URL.

### File renames
- `ConceptMap-CareCommunucation-Category.json` → `ConceptMap-CareCommunication-Category.json` (typo). Internal `id`/`url` are unchanged so no downstream references break.

### Other
- Restore `ehealth-relatedperson.relationship.coding` binding strength to `required`. The not-present `poa-privilege` CodeSystem in the `relatedperson-relationshiptype` ValueSet compose covers vendor codes, so loosening to `extensible` is unnecessary.
- Trailing-newline / typo / wording fixes in the profile intro and ConceptMap files.
- `sushi.sh`: switch the SUSHI warning filter from `sed` to `grep -v` (the `sed` form occasionally dropped surrounding lines).

### Changelog
Adds carecommunication-related entries under `9.0.2-SNAPSHOT` and the `status-reason` CS/VS entries.

## Notes for reviewers
- The `relationship.coding` strength change is the one potentially breaking item — please confirm the argument that the `poa-privilege` not-present CS handles vendor extensibility inside the ValueSet compose.
- No new behavior is intended; this is a structural/cleanup pass on top of the carecommunication profile merged in #242.