### PR TITLE
feat(ccr0316): add pårørende videomøde FHIR artefakter

### DIFF
--- a/input/fsh/ehealth-codesystem-message-channel.fsh
+++ b/input/fsh/ehealth-codesystem-message-channel.fsh
@@ -1,0 +1,7 @@
+CodeSystem: EhealthMessageChannelCS
+Id: ehealth-message-channel
+Title: "eHealth Message Channel codes"
+Description: "Codes indicating the channel used to send a message."
+* ^url = "http://ehealth.sundhed.dk/cs/ehealth-message-channel"
+* ^status = #active
+* #sms "SMS"

--- a/input/fsh/ehealth-codesystem-telecom-purpose.fsh
+++ b/input/fsh/ehealth-codesystem-telecom-purpose.fsh
@@ -1,0 +1,7 @@
+CodeSystem: EhealthTelecomPurposeCS
+Id: ehealth-telecom-purpose
+Title: "eHealth Telecom Purpose codes"
+Description: "Codes indicating the purpose of a telecom contact point."
+* ^url = "http://ehealth.sundhed.dk/cs/telecom-purpose"
+* ^status = #active
+* #video-appointment-reminder-sms "SMS-påmindelse til pårørende ved videomøde"

--- a/input/fsh/ehealth-codesystem-telecom-purpose.fsh
+++ b/input/fsh/ehealth-codesystem-telecom-purpose.fsh
@@ -4,4 +4,4 @@ Title: "eHealth Telecom Purpose codes"
 Description: "Codes indicating the purpose of a telecom contact point."
 * ^url = "http://ehealth.sundhed.dk/cs/telecom-purpose"
 * ^status = #active
-* #video-appointment-reminder-sms "SMS-påmindelse til pårørende ved videomøde"
+* #video-appointment-reminder-sms "SMS reminder to related person for video appointment"

--- a/input/fsh/ehealth-ext-telecom-purpose.fsh
+++ b/input/fsh/ehealth-ext-telecom-purpose.fsh
@@ -7,5 +7,5 @@ Description: "The purpose of a telecom contact point on a RelatedPerson."
 * ^context.expression = "RelatedPerson.telecom"
 * . ^short = "Purpose of telecom contact point"
 * value[x] only Coding
-* valueCoding 0..1
+* valueCoding 1..1
 * valueCoding from http://ehealth.sundhed.dk/vs/telecom-purpose (required)

--- a/input/fsh/ehealth-ext-telecom-purpose.fsh
+++ b/input/fsh/ehealth-ext-telecom-purpose.fsh
@@ -1,0 +1,11 @@
+Extension: ehealth-telecom-purpose
+Id: ehealth-telecom-purpose
+Title: "Telecom purpose"
+Description: "The purpose of a telecom contact point on a RelatedPerson."
+* ^url = "http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-telecom-purpose"
+* ^context.type = #element
+* ^context.expression = "RelatedPerson.telecom"
+* . ^short = "Purpose of telecom contact point"
+* value[x] only Coding
+* valueCoding 0..1
+* valueCoding from http://ehealth.sundhed.dk/vs/telecom-purpose (required)

--- a/input/fsh/ehealth-message.fsh
+++ b/input/fsh/ehealth-message.fsh
@@ -38,7 +38,7 @@ Parent: Communication
 * medium[DkTmMedium].coding.code from http://ehealth.sundhed.dk/vs/message-medium (required)
 
 * recipient 0..1
-* recipient only Reference(Patient or Practitioner)
+* recipient only Reference(Patient or Practitioner or ehealth-relatedperson)
 * recipient ^type.aggregation = #referenced
 * sender only Reference(Device or Patient or Practitioner)
 * sender ^type.aggregation[+] = #referenced
@@ -115,5 +115,5 @@ Severity:    #error
 
 Invariant:   advice-invariant
 Description: "Category advice invariant"
-Expression:  "category.coding.code contains 'advice' implies (recipient.reference.contains('Patient/') or extension.where(url = 'http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-communication-recipientCareTeam').value.as(Reference).exists()) and ( sender.reference.contains('Device/') or contained.ofType(Device).where('#' + id = %resource.sender.reference).empty().not())"
+Expression:  "category.coding.code contains 'advice' implies (recipient.reference.contains('Patient/') or recipient.reference.contains('RelatedPerson/') or extension.where(url = 'http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-communication-recipientCareTeam').value.as(Reference).exists()) and ( sender.reference.contains('Device/') or contained.ofType(Device).where('#' + id = %resource.sender.reference).empty().not())"
 Severity:    #error

--- a/input/fsh/ehealth-relatedperson.fsh
+++ b/input/fsh/ehealth-relatedperson.fsh
@@ -51,3 +51,21 @@ Usage: #example
 * address.postalCode = "8000"
 * address.country = "Danmark"
 * period.start = "2026-03-24"
+
+Instance: relatedperson-videosms
+InstanceOf: ehealth-relatedperson
+Usage: #example
+Title: "RelatedPerson with video-appointment SMS reminder telecom"
+Description: "Example RelatedPerson configured to receive an SMS reminder when a related video appointment is upcoming. The telecom slice carries the `ehealth-telecom-purpose` extension with code `video-appointment-reminder-sms`."
+* active = true
+* patient = Reference(Patient/102)
+* relationship.coding.system = "http://terminology.hl7.org/CodeSystem/v3-RoleCode"
+* relationship.coding.code = #SPS
+* name.use = #official
+* name.family = "Test"
+* name.given = "RelatedPerson"
+* telecom[video-appointment-reminder-sms].system = #phone
+* telecom[video-appointment-reminder-sms].value = "+4512345678"
+* telecom[video-appointment-reminder-sms].extension[purpose].url = "http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-telecom-purpose"
+* telecom[video-appointment-reminder-sms].extension[purpose].valueCoding.system = "http://ehealth.sundhed.dk/cs/telecom-purpose"
+* telecom[video-appointment-reminder-sms].extension[purpose].valueCoding.code = #video-appointment-reminder-sms

--- a/input/fsh/ehealth-relatedperson.fsh
+++ b/input/fsh/ehealth-relatedperson.fsh
@@ -15,6 +15,15 @@ Parent: RelatedPerson
 * relationship.coding from http://ehealth.sundhed.dk/vs/relatedperson-relationshiptype (extensible)
 * name 1..*
 
+* telecom ^slicing.discriminator.type = #value
+* telecom ^slicing.discriminator.path = "extension('http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-telecom-purpose').value.ofType(Coding).code"
+* telecom ^slicing.rules = #open
+* telecom contains sms-video-reminder 0..1
+* telecom[sms-video-reminder].system = #phone
+* telecom[sms-video-reminder].value 1..1
+* telecom[sms-video-reminder].extension contains ehealth-telecom-purpose named purpose 1..1
+* telecom[sms-video-reminder].extension[purpose].valueCoding from http://ehealth.sundhed.dk/vs/telecom-purpose (required)
+
 Instance: relatedperson01
 InstanceOf: RelatedPerson
 Usage: #example

--- a/input/fsh/ehealth-relatedperson.fsh
+++ b/input/fsh/ehealth-relatedperson.fsh
@@ -18,11 +18,11 @@ Parent: RelatedPerson
 * telecom ^slicing.discriminator.type = #value
 * telecom ^slicing.discriminator.path = "extension('http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-telecom-purpose').value.ofType(Coding).code"
 * telecom ^slicing.rules = #open
-* telecom contains sms-video-reminder 0..1
-* telecom[sms-video-reminder].system = #phone
-* telecom[sms-video-reminder].value 1..1
-* telecom[sms-video-reminder].extension contains ehealth-telecom-purpose named purpose 1..1
-* telecom[sms-video-reminder].extension[purpose].valueCoding from http://ehealth.sundhed.dk/vs/telecom-purpose (required)
+* telecom contains video-appointment-reminder-sms 0..1
+* telecom[video-appointment-reminder-sms].system = #phone
+* telecom[video-appointment-reminder-sms].value 1..1
+* telecom[video-appointment-reminder-sms].extension contains ehealth-telecom-purpose named purpose 1..1
+* telecom[video-appointment-reminder-sms].extension[purpose].valueCoding from http://ehealth.sundhed.dk/vs/telecom-purpose (required)
 
 Instance: relatedperson01
 InstanceOf: RelatedPerson

--- a/input/fsh/ehealth-relatedperson.fsh
+++ b/input/fsh/ehealth-relatedperson.fsh
@@ -23,6 +23,7 @@ Parent: RelatedPerson
 * telecom[video-appointment-reminder-sms].value 1..1
 * telecom[video-appointment-reminder-sms].extension contains ehealth-telecom-purpose named purpose 1..1
 * telecom[video-appointment-reminder-sms].extension[purpose].valueCoding from http://ehealth.sundhed.dk/vs/telecom-purpose (required)
+* telecom[video-appointment-reminder-sms].extension[purpose].valueCoding.code = #video-appointment-reminder-sms
 
 Instance: relatedperson01
 InstanceOf: RelatedPerson

--- a/input/fsh/ehealth-valueset-message-channel.fsh
+++ b/input/fsh/ehealth-valueset-message-channel.fsh
@@ -5,5 +5,3 @@ Description: "ValueSet for message channel codes."
 * ^url = "http://ehealth.sundhed.dk/vs/ehealth-message-channel"
 * ^status = #active
 * ^compose.include.system = "http://ehealth.sundhed.dk/cs/ehealth-message-channel"
-* ^compose.include.concept[+].code = #sms
-* ^compose.include.concept[=].display = "SMS"

--- a/input/fsh/ehealth-valueset-message-channel.fsh
+++ b/input/fsh/ehealth-valueset-message-channel.fsh
@@ -1,0 +1,9 @@
+ValueSet: EhealthMessageChannelVS
+Id: ehealth-message-channel
+Title: "eHealth Message Channel"
+Description: "ValueSet for message channel codes."
+* ^url = "http://ehealth.sundhed.dk/vs/ehealth-message-channel"
+* ^status = #active
+* ^compose.include.system = "http://ehealth.sundhed.dk/cs/ehealth-message-channel"
+* ^compose.include.concept[+].code = #sms
+* ^compose.include.concept[=].display = "SMS"

--- a/input/fsh/ehealth-valueset-telecom-purpose.fsh
+++ b/input/fsh/ehealth-valueset-telecom-purpose.fsh
@@ -1,0 +1,7 @@
+ValueSet: EhealthTelecomPurposeVS
+Id: ehealth-telecom-purpose
+Title: "eHealth Telecom Purpose"
+Description: "ValueSet for telecom purpose codes."
+* ^url = "http://ehealth.sundhed.dk/vs/telecom-purpose"
+* ^status = #active
+* ^compose.include.system = "http://ehealth.sundhed.dk/cs/telecom-purpose"

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -6,13 +6,19 @@ This is the log of changes made to the eHealth Implementation Guide.
 ### Custom operations
 #### System operations
 #### Instance operations
+- Added `Appointment/$send-message` instance operation for sending SMS messages to related persons associated with an appointment (CCR0316).
 ### Code systems
 - Re-added `http://ehealth.sundhed.dk/cs/poa-privilege` (Power of Attorney Privilege) CodeSystem. Content is `not-present` — codes are vendor-specific and externally governed.
+- Added `http://ehealth.sundhed.dk/cs/telecom-purpose` for telecom contact point purpose codes.
+- Added `http://ehealth.sundhed.dk/cs/ehealth-message-channel` for message channel codes (e.g. SMS).
 ### ValueSets
 - Re-added `http://ehealth.sundhed.dk/cs/poa-privilege` as an include in `http://ehealth.sundhed.dk/vs/relatedperson-relationshiptype`.
+- Added `http://ehealth.sundhed.dk/vs/telecom-purpose`.
+- Added `http://ehealth.sundhed.dk/vs/ehealth-message-channel`.
 ### ConceptMaps
 ### Resource/profile changes
 - Updated ehealth-media to allow patient and relatedPerson references in it's operator field.
+- Added `video-appointment-reminder-sms` telecom slice on `ehealth-relatedperson` for storing the SMS number used for video appointment reminders to related persons (CCR0316).
 
 ### Event messages
 - Tightened the `EHealthApplicationEvent` JSON schema (CCR0303 AC-7): the schema is now declared as JSON Schema draft-07; `eventType` and `resourceReference` are top-level required; `resourceReference` requires `minItems: 1` with each entry requiring both `label` and `reference`; and per-`eventType` `if`/`then`/`contains` rules assert the obligatory `resourceReference.label`. **Note for vendors:** producers must now emit both `label` and `reference` on every `resourceReference` entry and include the `eventType`-specific obligatory label.

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -6,7 +6,7 @@ This is the log of changes made to the eHealth Implementation Guide.
 ### Custom operations
 #### System operations
 #### Instance operations
-- Added `Appointment/$send-message` instance operation for sending SMS messages to related persons associated with an appointment (CCR0316).
+- Added `Appointment/$send-message` instance operation for sending an SMS reminder to a RelatedPerson participant of a video appointment (CCR0316). The recipient must be a RelatedPerson listed as a participant on the target Appointment; only the `sms` channel is currently supported.
 ### Code systems
 - Re-added `http://ehealth.sundhed.dk/cs/poa-privilege` (Power of Attorney Privilege) CodeSystem. Content is `not-present` — codes are vendor-specific and externally governed.
 - Added `http://ehealth.sundhed.dk/cs/telecom-purpose` for telecom contact point purpose codes.

--- a/input/resources/OperationDefinition-Appointment-send-message.json
+++ b/input/resources/OperationDefinition-Appointment-send-message.json
@@ -1,0 +1,54 @@
+{
+  "resourceType": "OperationDefinition",
+  "id": "Appointment-send-message",
+  "url": "http://ehealth.sundhed.dk/fhir/OperationDefinition/Appointment-send-message",
+  "name": "Appointment-send-message",
+  "title": "Send message",
+  "status": "active",
+  "kind": "operation",
+  "description": "Sends a message to a related person associated with an appointment via the specified channel.",
+  "affectsState": true,
+  "code": "send-message",
+  "resource": [
+    "Appointment"
+  ],
+  "system": false,
+  "type": false,
+  "instance": true,
+  "parameter": [
+    {
+      "name": "recipient",
+      "use": "in",
+      "min": 1,
+      "max": "1",
+      "documentation": "The related person to receive the message.",
+      "type": "Reference",
+      "targetProfile": [
+        "http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-relatedperson"
+      ]
+    },
+    {
+      "name": "channel",
+      "use": "in",
+      "min": 1,
+      "max": "1",
+      "documentation": "The channel to use when sending the message.",
+      "type": "code",
+      "binding": {
+        "strength": "required",
+        "valueSet": "http://ehealth.sundhed.dk/vs/ehealth-message-channel"
+      }
+    },
+    {
+      "name": "return",
+      "use": "out",
+      "min": 1,
+      "max": "1",
+      "documentation": "A reference to the created message resource.",
+      "type": "Reference",
+      "targetProfile": [
+        "http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-message"
+      ]
+    }
+  ]
+}

--- a/input/resources/OperationDefinition-Appointment-send-message.json
+++ b/input/resources/OperationDefinition-Appointment-send-message.json
@@ -6,7 +6,7 @@
   "title": "Send message",
   "status": "active",
   "kind": "operation",
-  "description": "Sends a message to a related person associated with an appointment via the specified channel.",
+  "description": "Sends a message to a related person associated with an appointment via the specified channel. The recipient must be a RelatedPerson listed as a participant on the target Appointment. The created ehealth-message resource is system-generated; its `sender` is expected to be a Device reference (typically a contained Device representing the issuing system).",
   "affectsState": true,
   "code": "send-message",
   "resource": [


### PR DESCRIPTION
## Summary

- Adds `Appointment/$send-message` instance operation for sending SMS to RelatedPersons associated with a video appointment (CCR0316)
- Adds `http://ehealth.sundhed.dk/cs/telecom-purpose` CodeSystem and `http://ehealth.sundhed.dk/vs/telecom-purpose` ValueSet for telecom contact point purpose codes
- Adds `http://ehealth.sundhed.dk/cs/ehealth-message-channel` CodeSystem and `http://ehealth.sundhed.dk/vs/ehealth-message-channel` ValueSet for message channel codes
- Adds `video-appointment-reminder-sms` telecom slice on `ehealth-relatedperson` for storing the SMS number used for video appointment reminders (CCR0316)
- Fixes `ehealth-carecommunication`: extracts code systems and value sets to separate FSH files, adds `ehealth-carecommunication-status-reason` CS/VS to document valid stopped-status reason codes, fixes ConceptMap filename typo (`CareCommunucation` → `CareCommunication`), removes redundant `only-asap-or-routine` invariant, adds explicit `Id` fields to extensions, and fixes minor typos throughout