### PR TITLE
adjust invariant to not require type of attachment when it is a url

### DIFF
--- a/input/fsh/ehealth-carecommunication.fsh
+++ b/input/fsh/ehealth-carecommunication.fsh
@@ -298,8 +298,8 @@ Expression: "payload.contentString.exists()"
 Severity: #error
 
 Invariant: payloadAttachment-contentType-required
-Description: "contentType SHALL be present if data or url is present in Attachment"
-Expression: "payload.contentAttachment.data.exists() or payload.contentAttachment.url.exists() implies payload.contentAttachment.contentType.exists()"
+Description: "contentType SHALL be present when the attachment content is in the data element. It is not required for url-only attachments."
+Expression: "payload.contentAttachment.data.exists() implies payload.contentAttachment.contentType.exists()"
 Severity: #error
 
 Invariant: no-standard-sender


### PR DESCRIPTION
- [ ] I have ensured the target branch is correct; for new changes, they target e.g. `release-3.5.0`. Only release branches should target `master`. For more details, see [here](../RELEASE.md).

The IG is materialised as a website automatically by CI, and can be found [here](http://build.fhir.org/ig/fut-infrastructure/implementation-guide/branches/).