### PR TITLE
fix(ccr0316): set RelatedPerson video-reminder telecom system to sms

### DIFF
--- a/input/fsh/ehealth-relatedperson.fsh
+++ b/input/fsh/ehealth-relatedperson.fsh
@@ -19,7 +19,7 @@ Parent: RelatedPerson
 * telecom ^slicing.discriminator.path = "extension('http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-telecom-purpose').value.ofType(Coding).code"
 * telecom ^slicing.rules = #open
 * telecom contains video-appointment-reminder-sms 0..1
-* telecom[video-appointment-reminder-sms].system = #phone
+* telecom[video-appointment-reminder-sms].system = #sms
 * telecom[video-appointment-reminder-sms].value 1..1
 * telecom[video-appointment-reminder-sms].extension contains ehealth-telecom-purpose named purpose 1..1
 * telecom[video-appointment-reminder-sms].extension[purpose].valueCoding from http://ehealth.sundhed.dk/vs/telecom-purpose (required)
@@ -65,7 +65,7 @@ Description: "Example RelatedPerson configured to receive an SMS reminder when a
 * name.use = #official
 * name.family = "Test"
 * name.given = "RelatedPerson"
-* telecom[video-appointment-reminder-sms].system = #phone
+* telecom[video-appointment-reminder-sms].system = #sms
 * telecom[video-appointment-reminder-sms].value = "+4512345678"
 * telecom[video-appointment-reminder-sms].extension[purpose].url = "http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-telecom-purpose"
 * telecom[video-appointment-reminder-sms].extension[purpose].valueCoding.system = "http://ehealth.sundhed.dk/cs/telecom-purpose"


### PR DESCRIPTION
## Summary

CCR0316 v2 §3 (ContactPoint table) and §4 (slice constraint) specify
`ContactPoint.system = sms` for the `video-appointment-reminder-sms` telecom
slice on `ehealth-relatedperson`. PR #286 inadvertently fixed both the slice
constraint and its example instance to `#phone` instead.

This fix:

- `telecom[video-appointment-reminder-sms].system` constraint → `#sms`
- `relatedperson-videosms` example instance telecom `system` → `#sms`

## Impact downstream

fut-patient ([PR #3334](https://github.com/trifork/ehealth/pull/3334)) currently has to match the live IG and uses `ContactPoint.ContactPointSystem.PHONE` to look up the video-reminder telecom. Once this IG fix ships in a new ehealth-core release and fut-ig-installer bumps to that version, that workaround can be reverted to use `SMS` (matching the CCR).