### PR TITLE
[FUT1-22730] Removed measurement resources from investigationOtherItem

### DIFF
--- a/input/fsh/ehealth-clinicalimpression.fsh
+++ b/input/fsh/ehealth-clinicalimpression.fsh
@@ -94,7 +94,7 @@ Extension:   ehealth-clinicalimpression-otherItem
 Title:       "Other item"
 Description: "Investigation item for Aggregated Triage resources so they can be approved."
 * . ^short = "Other item"
-* value[x] only Reference(ehealth-clinicalimpression or ehealth-provenance or ehealth-observation or ehealth-questionnaireresponse or ehealth-media)
+* value[x] only Reference(ehealth-clinicalimpression or ehealth-provenance)
 * value[x] ^type.aggregation = #referenced
 
 Extension:   ehealth-questionnaireresponse-finding-basis


### PR DESCRIPTION
- [X] I have ensured the target branch is correct; for new changes, they target e.g. `release-3.5.0`. Only release branches should target `master`. For more details, see [here](../RELEASE.md).

The IG is materialised as a website automatically by CI, and can be found [here](http://build.fhir.org/ig/fut-infrastructure/implementation-guide/branches/).