### PR TITLE
actual search parameter for carecommunication practitioner sender

### DIFF
--- a/input/resources/SearchParameter-ehealth-communication-search-careCommunicationSenderPractitioner.json
+++ b/input/resources/SearchParameter-ehealth-communication-search-careCommunicationSenderPractitioner.json
@@ -1,0 +1,16 @@
+{
+    "resourceType": "SearchParameter",
+    "id": "ehealth-communication-search-careCommunicationSenderPractitioner",
+    "url": "http://ehealth.sundhed.dk/fhir/SearchParameter/Communication/careCommunicationSenderPractitioner",
+    "name": "careCommunicationSenderPractitioner",
+    "status": "active",
+    "date": "2026-06-12T00:00:00+00:00",
+    "code": "careCommunicationSenderPractitioner",
+    "base": [
+        "Communication"
+    ],
+    "type": "reference",
+    "description": "Search parameter for finding CareCommunication based on the sending Practitioner (the practitioner sub-extension of the ehealth-carecommunication-sender extension).",
+    "expression": "Communication.extension('http://ehealth.sundhed.dk/fhir/StructureDefinition/ehealth-carecommunication-sender').extension('practitioner').value",
+    "xpathUsage": "normal"
+}


### PR DESCRIPTION
- [ ] I have ensured the target branch is correct; for new changes, they target e.g. `release-3.5.0`. Only release branches should target `master`. For more details, see [here](../RELEASE.md).

The IG is materialised as a website automatically by CI, and can be found [here](http://build.fhir.org/ig/fut-infrastructure/implementation-guide/branches/).