### PR TITLE
typo in ehealth-patient ydernummer system required pattern

### DIFF
--- a/input/fsh/ehealth-patient.fsh
+++ b/input/fsh/ehealth-patient.fsh
@@ -48,7 +48,7 @@ Parent: DkCorePatient
 * generalPractitioner contains YderNummer 0..1
 * generalPractitioner[YderNummer].identifier 1..1
 * generalPractitioner[YderNummer].identifier.system 1..1
-* generalPractitioner[YderNummer].identifier.system = "urn:oid.1.2.208.176.1.4"
+* generalPractitioner[YderNummer].identifier.system = "urn:oid:1.2.208.176.1.4"
 * generalPractitioner[YderNummer].identifier.value 1..1
 
 Extension: ehealth-itcompetencelevel

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -36,6 +36,7 @@ This is the log of changes made to the eHealth Implementation Guide.
 - Updated `http://ehealth.sundhed.dk/ConceptMap/conceptmap-ucum-to-printsymbol` to include mapping for `MCS88214`.
 
 ### Resource/profile changes
+- Fixed the `identifier.system` pattern on the `YderNummer` slice of `ehealth-patient.generalPractitioner` from `urn:oid.1.2.208.176.1.4` to `urn:oid:1.2.208.176.1.4`, so Ydernummer references are correctly matched to the slice.
 - Updated ehealth-media to allow patient and relatedPerson references in it's operator field.
 - Added `video-appointment-reminder-sms` telecom slice on `ehealth-relatedperson` for storing the SMS number used for video appointment reminders to related persons (CCR0316).
 - Added search parameter `careCommunicationSenderPractitioner` on `ehealth-communication` to query CareCommunication by the sending Practitioner (the `practitioner` sub-extension of the `ehealth-carecommunication-sender` extension).


### PR DESCRIPTION
- [ ] I have ensured the target branch is correct; for new changes, they target e.g. `release-3.5.0`. Only release branches should target `master`. For more details, see [here](../RELEASE.md).

The IG is materialised as a website automatically by CI, and can be found [here](http://build.fhir.org/ig/fut-infrastructure/implementation-guide/branches/).