### PR TITLE
[FUT1-23424] Added new codes in participant-function code system.

### DIFF
--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -24,6 +24,7 @@ This is the log of changes made to the eHealth Implementation Guide.
 - Updated `http://ehealth.sundhed.dk/cs/ehealth-ucum-printsymbol-supplement` to include new unit for 1/60sec for `MCS88214` 
 - Added `http://ehealth.sundhed.dk/cs/ehealth-aggregation-mode-types`
 - Added `http://ehealth.sundhed.dk/cs/device-platform` with codes `APN` (Apple Push Notification service) and `FCM` (Firebase Cloud Messaging) for identifying the push notification service used by a citizen's mobile device.
+- Updated `http://ehealth.sundhed.dk/cs/participant-function` with codes `administrative`, `monitoring`, `supporting` and `informed`.
 ### ValueSets
 - Re-added `http://ehealth.sundhed.dk/cs/poa-privilege` as an include in `http://ehealth.sundhed.dk/vs/relatedperson-relationshiptype`.
 - Added `http://ehealth.sundhed.dk/vs/telecom-purpose`.

--- a/input/resources/CodeSystem-ehealth-participant-function.json
+++ b/input/resources/CodeSystem-ehealth-participant-function.json
@@ -54,6 +54,50 @@
           "value": "Standard careteam for opgaver og kommunikation"
         }
       ]
+    },
+    {
+      "code": "administrative",
+      "display": "Administrative",
+      "definition": "Participant has administrative function of maintaining EpisodeOfCare and/or CarePlan",
+      "designation": [
+        {
+          "language": "da",
+          "value": "administrerende"
+        }
+      ]
+    },
+    {
+      "code": "monitoring",
+      "display": "Monitoring",
+      "definition": "Participant monitors Patient's submissions and adherence to plan",
+      "designation": [
+        {
+          "language": "da",
+          "value": "monitorerende"
+        }
+      ]
+    },
+    {
+      "code": "supporting",
+      "display": "Supporting",
+      "definition": "Participant supports other participants, for instance by setting up and adjusting EpisodeOfCare and/or CarePlan",
+      "designation": [
+        {
+          "language": "da",
+          "value": "supporterende"
+        }
+      ]
+    },
+    {
+      "code": "informed",
+      "display": "Informed",
+      "definition": "Participant is involved to stay informed and expected to perform few if any actions",
+      "designation": [
+        {
+          "language": "da",
+          "value": "informeret"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
- [ ] I have ensured the target branch is correct; for new changes, they target e.g. `release-3.5.0`. Only release branches should target `master`. For more details, see [here](../RELEASE.md).

The IG is materialised as a website automatically by CI, and can be found [here](http://build.fhir.org/ig/fut-infrastructure/implementation-guide/branches/).