### PR TITLE
[FUT1-24260] Added 4 new telma konfiguration codes

### DIFF
--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -25,6 +25,7 @@ This is the log of changes made to the eHealth Implementation Guide.
 - Added `http://ehealth.sundhed.dk/cs/ehealth-aggregation-mode-types`
 - Added `http://ehealth.sundhed.dk/cs/device-platform` with codes `APN` (Apple Push Notification service) and `FCM` (Firebase Cloud Messaging) for identifying the push notification service used by a citizen's mobile device.
 - Updated `http://ehealth.sundhed.dk/cs/participant-function` with codes `administrative`, `monitoring`, `supporting` and `informed`.
+- Updated `http://ehealth.sundhed.dk/cs/ehealth-program` with 4 new `telma-konfiguration-x` codes.
 ### ValueSets
 - Re-added `http://ehealth.sundhed.dk/cs/poa-privilege` as an include in `http://ehealth.sundhed.dk/vs/relatedperson-relationshiptype`.
 - Added `http://ehealth.sundhed.dk/vs/telecom-purpose`.

--- a/input/resources/CodeSystem-ehealth-program.json
+++ b/input/resources/CodeSystem-ehealth-program.json
@@ -39,6 +39,26 @@
       "definition": "Supportteam for Telemedicinsk monitoreringsapplikation"
     },
     {
+      "code": "telma-konfiguration-1",
+      "display": "Telma Konfiguration 1",
+      "definition": "Konfiguration 1 for Telemedicinsk monitoreringsapplikation"
+    },
+    {
+      "code": "telma-konfiguration-2",
+      "display": "Telma Konfiguration 2",
+      "definition": "Konfiguration 2 for Telemedicinsk monitoreringsapplikation"
+    },
+    {
+      "code": "telma-konfiguration-3",
+      "display": "Telma Konfiguration 3",
+      "definition": "Konfiguration 3 for Telemedicinsk monitoreringsapplikation"
+    },
+    {
+      "code": "telma-konfiguration-4",
+      "display": "Telma Konfiguration 4",
+      "definition": "Konfiguration 4 for Telemedicinsk monitoreringsapplikation"
+    },
+    {
       "code": "fob",
       "display": "FOB",
       "definition": "Fællesoffentlig Behandlingsplatform"


### PR DESCRIPTION
- [x] I have ensured the target branch is correct; for new changes, they target e.g. `release-3.5.0`. Only release branches should target `master`. For more details, see [here](../RELEASE.md).

The IG is materialised as a website automatically by CI, and can be found [here](http://build.fhir.org/ig/fut-infrastructure/implementation-guide/branches/).