### PR TITLE
chore(CCR0298): rename seb-style competences

### DIFF
--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -28,7 +28,7 @@ This is the log of changes made to the eHealth Implementation Guide.
 - Added `http://ehealth.sundhed.dk/cs/device-platform` with codes `APN` (Apple Push Notification service) and `FCM` (Firebase Cloud Messaging) for identifying the push notification service used by a citizen's mobile device.
 - Updated `http://ehealth.sundhed.dk/cs/participant-function` with codes `administrative`, `monitoring`, `supporting` and `informed`.
 - Added `http://ehealth.sundhed.dk/cs/practitioner-competences` (Practitioner Competences) with codes `woundTeleCourse` and `woundDiploma` for decentralized practitioner competences (CCR0298).
-- Added `http://ehealth.sundhed.dk/cs/oio-bpp-competences` (OIO-BPP Competences) with the wound telecourse/diploma competence codes, in both `urn:dk:sundhed:ehealth:competence:...` and `http://ehealth.seb.dk/competence/usercompetence/...` variants (CCR0298).
+- Added `http://ehealth.sundhed.dk/cs/oio-bpp-competences` (OIO-BPP Competences) with the wound telecourse/diploma competence codes, in both `urn:dk:sundhed:ehealth:competence:...` and `http://ehealth.seb.dk/roles/usersystemrole/competence_...` variants (CCR0298).
 - Updated `http://ehealth.sundhed.dk/cs/ehealth-program` with 4 new `telma-konfiguration-x` codes.
 ### ValueSets
 - Re-added `http://ehealth.sundhed.dk/cs/poa-privilege` as an include in `http://ehealth.sundhed.dk/vs/relatedperson-relationshiptype`.

--- a/input/resources/CodeSystem-ehealth-oio-bpp-competences.json
+++ b/input/resources/CodeSystem-ehealth-oio-bpp-competences.json
@@ -46,7 +46,7 @@
             ]
         },
         {
-          "code": "http://ehealth.seb.dk/competence/usercompetence/wound_telecourse/1",
+          "code": "http://ehealth.seb.dk/roles/usersystemrole/competence_wound_telecourse/1",
           "display": "Wound Telecourse",
           "definition": "Kvalificeret til at anvende telemedicinsk sårvurdering via gennemført telemedicinsk sårkursus.",
           "designation": [
@@ -57,7 +57,7 @@
           ]
         },
         {
-            "code": "http://ehealth.seb.dk/competence/usercompetence/wound_diploma/1",
+            "code": "http://ehealth.seb.dk/roles/usersystemrole/competence_wound_diploma/1",
             "display": "Wound Diploma",
             "definition": "Har gennemført diplommodul eller længerevarende efteruddannelse i sår behandling",
             "designation": [

--- a/input/resources/ConceptMap-ehealth.sundhed.dk-ConceptMap-oio-bpp-competences-to-practitioner-competences.json
+++ b/input/resources/ConceptMap-ehealth.sundhed.dk-ConceptMap-oio-bpp-competences-to-practitioner-competences.json
@@ -24,8 +24,8 @@
   "targetUri": "http://ehealth.sundhed.dk/vs/practitioner-competences",
   "group": [
     {
-      "source": "http://ehealth.sundhed.dk/cs/oio-bpp-roles",
-      "target": "http://ehealth.sundhed.dk/vs/practitioner-competences",
+      "source": "http://ehealth.sundhed.dk/cs/oio-bpp-competences",
+      "target": "http://ehealth.sundhed.dk/cs/practitioner-competences",
       "element": [
         {
           "code": "urn:dk:sundhed:ehealth:competence:wound_telecourse",

--- a/input/resources/ConceptMap-ehealth.sundhed.dk-ConceptMap-oio-bpp-competences-to-practitioner-competences.json
+++ b/input/resources/ConceptMap-ehealth.sundhed.dk-ConceptMap-oio-bpp-competences-to-practitioner-competences.json
@@ -46,7 +46,7 @@
           ]
         },
         {
-          "code": "http://ehealth.seb.dk/competence/usercompetence/wound_telecourse/1",
+          "code": "http://ehealth.seb.dk/roles/usersystemrole/competence_wound_telecourse/1",
           "target": [
             {
               "code": "woundTeleCourse",
@@ -55,7 +55,7 @@
           ]
         },
         {
-          "code": "http://ehealth.seb.dk/competence/usercompetence/wound_diploma/1",
+          "code": "http://ehealth.seb.dk/roles/usersystemrole/competence_wound_diploma/1",
           "target": [
             {
               "code": "woundDiploma",


### PR DESCRIPTION
- [x] I have ensured the target branch is correct; for new changes, they target e.g. `release-3.5.0`. Only release branches should target `master`. For more details, see [here](../RELEASE.md).

The IG is materialised as a website automatically by CI, and can be found [here](http://build.fhir.org/ig/fut-infrastructure/implementation-guide/branches/).