### PR TITLE
docs(event-messages): align documented EHealthApplicationEvent required fields with shipped schema (CCR0303 AC-9)

### DIFF
--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -77,7 +77,7 @@ This is the log of changes made to the eHealth Implementation Guide.
 - Added search parameter "qualification-identifier" for Practitioner resources, to be able to query Practitioners with a specific qualification identifier (CCR0298).
 
 ### Event messages
-- Tightened the `EHealthApplicationEvent` JSON schema (CCR0303 AC-7): the schema is now declared as JSON Schema draft-07; `eventType` and `resourceReference` are top-level required; `resourceReference` requires `minItems: 1` with each entry requiring both `label` and `reference`; and per-`eventType` `if`/`then`/`contains` rules assert the obligatory `resourceReference.label`. **Note for vendors:** producers must now emit both `label` and `reference` on every `resourceReference` entry and include the `eventType`-specific obligatory label.
+- Tightened the `EHealthApplicationEvent` JSON schema (CCR0303 AC-7): the schema is now declared as JSON Schema draft-07; all message fields (`messageType`, `messageVersion`, `ehealth.system`, `eventType`, `payload`, `userReference`, `resourceReference`) are top-level required; `resourceReference` requires `minItems: 1` with each entry requiring both `label` and `reference`; and per-`eventType` `if`/`then`/`contains` rules assert the obligatory `resourceReference.label`. **Note for vendors:** producers must now emit both `label` and `reference` on every `resourceReference` entry and include the `eventType`-specific obligatory label.
 
 ## 9.0.2-SNAPSHOT (2026-05-04)
 ### Code systems

--- a/input/pagecontent/event-messages.md
+++ b/input/pagecontent/event-messages.md
@@ -136,7 +136,7 @@ topic: `ehealth-application-event`
   "$schema" : "http://json-schema.org/draft-07/schema#",
   "type" : "object",
   "id" : "urn:jsonschema:dk:sundhed:ehealth:event:models:EHealthApplicationEvent",
-  "required" : [ "eventType", "resourceReference" ],
+  "required" : [ "messageType", "messageVersion", "ehealth.system", "eventType", "payload", "userReference", "resourceReference" ],
   "properties" : {
     "messageType" : {
       "type" : "string",


### PR DESCRIPTION
## Summary

Follow-up to [#270](https://github.com/fut-infrastructure/implementation-guide/pull/270). The inline `EHealthApplicationEvent` schema in `event-messages.md` listed only `eventType` and `resourceReference` as top-level `required`, but the shipped schema (`eHealthApplicationEvent.json` in trifork/ehealth) requires **all 7 fields** — including `ehealth.system`, the coexistence tag mandated by AC-CCR0303-8.

A subscriber validating a received event against the *documented* schema would under-validate: it would accept events missing `messageType`, `messageVersion`, `ehealth.system`, `payload` or `userReference`, which the real schema rejects. AC-CCR0303-9 requires MQ events to *validate correctly against this schema*, so the documented schema must match the shipped one.

### Changes

- `input/pagecontent/event-messages.md` — the inline schema's top-level `required` array now lists all 7 fields (`messageType`, `messageVersion`, `ehealth.system`, `eventType`, `payload`, `userReference`, `resourceReference`), matching the shipped schema exactly.
- `input/pagecontent/changelog.md` — the `### Event messages` bullet's "top-level required" phrase updated to the full field list.

No FSH / StructureDefinition changes; `properties` list and Event Types table already described all fields — only the `required` array was stale.

### Cross-repo reference

- Shipped schema: `code/ehealth-commons/.../schema/eHealthApplicationEvent.json` in trifork/ehealth.
- Closes the documentation half of trifork/ehealth#3820 (AC-CCR0303-9).