### PR TITLE
[FUT1-24530] Add ehealth-intendedQuestionnaireLinkage extension to Pl…

### DIFF
--- a/input/fsh/ehealth-ext-intendedQuestionnaireLinkage.fsh
+++ b/input/fsh/ehealth-ext-intendedQuestionnaireLinkage.fsh
@@ -1,0 +1,6 @@
+Extension: ehealth-intendedQuestionnaireLinkage
+Title: "intendedQuestionnaireLinkage"
+Description: "References the QuestionnaireLinkage(s) intended to be used when presenting the questionnaire responses of the action/service request, e.g. for cross-questionnaire or cross-version comparison. On PlanDefinition.action (any nesting level) it designates the linkages recommended by the plan template author; $apply copies it to the created ServiceRequest."
+* . ^short = "QuestionnaireLinkage(s) intended for presenting the questionnaire responses of the action/service request"
+* value[x] only Reference(ehealth-questionnairelinkage)
+* valueReference 1..1

--- a/input/fsh/ehealth-plandefinition.fsh
+++ b/input/fsh/ehealth-plandefinition.fsh
@@ -17,6 +17,7 @@ Parent: PlanDefinition
 * action.definition[x] only Canonical(ehealth-activitydefinition or ehealth-plandefinition)
 * action.extension contains ehealth-actionTrigger named ehealth-actionTrigger 0..1
 * action.extension contains ehealth-include-as-extra named includeAsExtra 0..1
+* action.extension contains ehealth-intendedQuestionnaireLinkage named intendedQuestionnaireLinkage 0..*
 
 Extension: ehealth-actionTrigger
 Title:     "Action Trigger"

--- a/input/fsh/ehealth-servicerequest.fsh
+++ b/input/fsh/ehealth-servicerequest.fsh
@@ -12,6 +12,7 @@ Parent: ServiceRequest
 * extension contains ehealth-servicerequest-statusHistory named statusHistory 0..*
 * extension contains ehealth-servicerequest-statusSchedule named statusSchedule 0..*
 * extension contains ehealth-include-as-extra named includeAsExtra 1..1
+* extension contains ehealth-intendedQuestionnaireLinkage named intendedQuestionnaireLinkage 0..*
 
 * instantiatesCanonical 1..1
 * instantiatesCanonical only Canonical(ehealth-activitydefinition)

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -7,6 +7,7 @@ This is the log of changes made to the eHealth Implementation Guide.
 - Added `ehealth-questionnairelinkage-for` extension (0..* version-specific Reference(ehealth-questionnaire) — the questionnaires participating in a linkage)
 - Added `ehealth-questionnairelinkage-item` extension (0..* groups of linked questions: optional description + linkage pairs of questionnaire reference and linkId)
 - Added `ehealth-basic-name` extension (computer-friendly name, complementing `ehealth-basic-title`; used by `ehealth-questionnairelinkage`)
+- Added `ehealth-intendedQuestionnaireLinkage` extension (0..* Reference(ehealth-questionnairelinkage)) on `PlanDefinition.action` (any nesting level) and on `ehealth-servicerequest` — the linkages intended for presenting the questionnaire responses of the action/service request; copied action to ServiceRequest by PlanDefinition/$apply (CCR0317 Option 1, FDD0197)
 ### Code systems
 - Added `questionnairelinkage` (Spørgeskemasammenknytning) to http://ehealth.sundhed.dk/cs/basic-resource-type
 ### Search parameters


### PR DESCRIPTION
…anDefinition.action and ServiceRequest

- [ ] I have ensured the target branch is correct; for new changes, they target e.g. `release-3.5.0`. Only release branches should target `master`. For more details, see [here](../RELEASE.md).

The IG is materialised as a website automatically by CI, and can be found [here](http://build.fhir.org/ig/fut-infrastructure/implementation-guide/branches/).