### PR TITLE
Changes to release 2026.3 version 10.0.0

### DIFF
--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -8,6 +8,7 @@ This is the log of changes made to the eHealth Implementation Guide.
 ### Code systems
 - Changed danish designation text to `Fastende blodsukker` for `NPU02193` in code system `urn:oid:1.2.208.176.2.1`.
 ### ValueSets
+- Updated `http://ehealth.sundhed.dk/vs/ehealth-treatment-area-collection-xb` and `http://ehealth.sundhed.dk/vs/ehealth-treatment-area-collection-xc` ValueSets specify includes as union rather than intersection, as specified by the fhir spec.
 ### ConceptMaps
 ### Resource/profile changes
 ### Search parameters

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -8,7 +8,7 @@ This is the log of changes made to the eHealth Implementation Guide.
 ### Code systems
 - Changed danish designation text to `Fastende blodsukker` for `NPU02193` in code system `urn:oid:1.2.208.176.2.1`.
 ### ValueSets
-- Updated `http://ehealth.sundhed.dk/vs/ehealth-treatment-area-collection-xb` and `http://ehealth.sundhed.dk/vs/ehealth-treatment-area-collection-xc` ValueSets specify includes as union rather than intersection, as specified by the fhir spec.
+- Updated `http://ehealth.sundhed.dk/vs/ehealth-treatment-area-collection-xb` and `http://ehealth.sundhed.dk/vs/ehealth-treatment-area-collection-xc` ValueSets to specify includes as union rather than intersection, as specified by the fhir spec.
 ### ConceptMaps
 ### Resource/profile changes
 ### Search parameters

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -1,5 +1,19 @@
 This is the log of changes made to the eHealth Implementation Guide.
 
+## 10.0.1 (2026-08-26)
+### General changes
+### Custom operations
+#### System operations
+#### Instance operations
+### Code systems
+- Changed danish designation text to `Fastende blodsukker` for `NPU02193` in code system `urn:oid:1.2.208.176.2.1`.
+### ValueSets
+### ConceptMaps
+### Resource/profile changes
+### Search parameters
+### Event messages
+
+
 ## 10.0.0 (2026-08-26)
 ### General changes
 - Updated ehealth-media to allow patient and relatedPerson references in it's operator field.

--- a/input/resources/CodeSystem-urn-oid-1.2.208.176.2.1.json
+++ b/input/resources/CodeSystem-urn-oid-1.2.208.176.2.1.json
@@ -47,7 +47,7 @@
             "system": "http://terminology.hl7.org/CodeSystem/hl7TermMaintInfra",
             "code": "consumer"
           },
-          "value": "Blodsukker"
+          "value": "Fastende blodsukker"
         }
       ]
     },

--- a/input/resources/ValueSet-ehealth-treatment-area-collection-xb.json
+++ b/input/resources/ValueSet-ehealth-treatment-area-collection-xb.json
@@ -41,12 +41,36 @@
     "include": [
       {
         "valueSet": [
-          "http://ehealth.sundhed.dk/vs/ehealth-treatment-area-xb-1",
-          "http://ehealth.sundhed.dk/vs/ehealth-treatment-area-xb-2",
-          "http://ehealth.sundhed.dk/vs/ehealth-treatment-area-xb-3",
-          "http://ehealth.sundhed.dk/vs/ehealth-treatment-area-xb-4",
-          "http://ehealth.sundhed.dk/vs/ehealth-treatment-area-xb-5",
-          "http://ehealth.sundhed.dk/vs/ehealth-treatment-area-xb-6",
+          "http://ehealth.sundhed.dk/vs/ehealth-treatment-area-xb-1"
+        ]
+      },
+      {
+        "valueSet": [
+          "http://ehealth.sundhed.dk/vs/ehealth-treatment-area-xb-2"
+        ]
+      },
+      {
+        "valueSet": [
+          "http://ehealth.sundhed.dk/vs/ehealth-treatment-area-xb-3"
+        ]
+      },
+      {
+        "valueSet": [
+          "http://ehealth.sundhed.dk/vs/ehealth-treatment-area-xb-4"
+        ]
+      },
+      {
+        "valueSet": [
+          "http://ehealth.sundhed.dk/vs/ehealth-treatment-area-xb-5"
+        ]
+      },
+      {
+        "valueSet": [
+          "http://ehealth.sundhed.dk/vs/ehealth-treatment-area-xb-6"
+        ]
+      },
+      {
+        "valueSet": [
           "http://ehealth.sundhed.dk/vs/ehealth-treatment-area-xb-7"
         ]
       }

--- a/input/resources/ValueSet-ehealth-treatment-area-collection-xc.json
+++ b/input/resources/ValueSet-ehealth-treatment-area-collection-xc.json
@@ -41,8 +41,16 @@
     "include": [
       {
         "valueSet": [
-          "http://ehealth.sundhed.dk/vs/ehealth-treatment-area-xc-1",
-          "http://ehealth.sundhed.dk/vs/ehealth-treatment-area-xc-2",
+          "http://ehealth.sundhed.dk/vs/ehealth-treatment-area-xc-1"
+        ]
+      },
+      {
+        "valueSet": [
+          "http://ehealth.sundhed.dk/vs/ehealth-treatment-area-xc-2"
+        ]
+      },
+      {
+        "valueSet": [
           "http://ehealth.sundhed.dk/vs/ehealth-treatment-area-xc-3"
         ]
       }

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,1 +1,1 @@
-* See detailed changes in [the changelog](https://ehealth.sundhed.dk/fhir/changelog.html#1000-2026-08-26)
+* See detailed changes in [the changelog](https://ehealth.sundhed.dk/fhir/changelog.html#1001-2026-08-26)

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -7,7 +7,7 @@ canonical: http://ehealth.sundhed.dk/fhir
 name: eHealth Infrastructure
 title: eHealth Infrastructure
 status: active # draft | active | retired | unknown
-version: 10.0.0
+version: 10.0.1
 fhirVersion: 4.0.1
 copyrightYear: 2021+
 


### PR DESCRIPTION
Changed consumer text for NPU2193 by request from FUT/Tele wound project.

- [ ] I have ensured the target branch is correct; for new changes, they target e.g. `release-3.5.0`. Only release branches should target `master`. For more details, see [here](../RELEASE.md).

The IG is materialised as a website automatically by CI, and can be found [here](http://build.fhir.org/ig/fut-infrastructure/implementation-guide/branches/).