### PR TITLE
Constrain ehealth-skrs-patient generalPractitioner to 0..1

### DIFF
--- a/input/fsh/ehealth-skrs-patient.fsh
+++ b/input/fsh/ehealth-skrs-patient.fsh
@@ -27,6 +27,8 @@ Parent: Patient
 * address[officialHomeAddress].extension contains http://hl7.dk/fhir/core/StructureDefinition/dk-core-municipalityCodes named municipalityCodes 0..*
 * address[officialHomeAddress].extension contains http://hl7.dk/fhir/core/StructureDefinition/dk-core-RegionalSubDivisionCodes named regionalSubDivisionCodes 0..*
 
+* generalPractitioner 0..1
+
 
 Instance: 291
 InstanceOf: Patient

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -11,6 +11,7 @@ This is the log of changes made to the eHealth Implementation Guide.
 - Updated `http://ehealth.sundhed.dk/vs/ehealth-treatment-area-collection-xb` and `http://ehealth.sundhed.dk/vs/ehealth-treatment-area-collection-xc` ValueSets to specify includes as union rather than intersection, as specified by the fhir spec.
 ### ConceptMaps
 ### Resource/profile changes
+- Constrained `generalPractitioner` on `ehealth-skrs-patient` to `0..1`, matching the `ehealth-patient` profile and the fut-patient server's enforcement that a citizen has at most one active GP.
 ### Search parameters
 ### Event messages
 


### PR DESCRIPTION
## Summary
- `ehealth-skrs-patient` had no cardinality constraint on `generalPractitioner` at all (inherited base FHIR's unconstrained `0..*`), even though `ehealth-patient` (the canonical stored profile) already constrains it to `0..1`.
- fut-patient's `updatePatientSKRS` operation now rejects any incoming SKRS patient payload carrying more than one `generalPractitioner` reference (trifork/ehealth#4062), since a citizen only ever has one active GP.
- This brings the profile's declared contract in line with that enforced business rule.